### PR TITLE
feat: 支持 typesOnly 选项

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -99,8 +99,8 @@ export class Generator {
                         ].join('\n\n')
                         if (!outputFileList[outputFilePath]) {
                           outputFileList[outputFilePath] = {
-                            content: [],
                             syntheticalConfig,
+                            content: [],
                             requestFilePath: (
                               syntheticalConfig.requestFunctionFilePath
                                 ? path.resolve(
@@ -134,7 +134,7 @@ export class Generator {
       Object.keys(outputFileList).map(async outputFilePath => {
         const { content, requestFilePath, syntheticalConfig } = outputFileList[outputFilePath]
 
-        // 若 request 文件不存在，则写入 request 文件
+        // 若 request 文件不存在，或者不在typesOnly模式下，则写入 request 文件
         if (!(await fs.pathExists(requestFilePath)) && !syntheticalConfig.typesOnly) {
           await fs.outputFile(
             requestFilePath,

--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -67,7 +67,6 @@ export class Generator {
                           ...serverConfig,
                           ...projectConfig,
                           ...categoryConfig,
-                          typesOnly: serverConfig.typesOnly,
                           mockUrl: projectInfo.getMockUrl(),
                         }
                         syntheticalConfig.devUrl = projectInfo.getDevUrl(syntheticalConfig.devEnvName!)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra'
 import ora from 'ora'
 import path from 'path'
 import prompt from 'prompts'
-import { CliConfig } from './types'
+import { Config } from './types'
 import { Generator } from './Generator'
 
 TSNode.register({
@@ -37,37 +37,35 @@ TSNode.register({
             if (!answers.override) return
           }
           await fs.outputFile(configFile, `${`
-            import { CliConfig } from 'yapi-to-typescript'
+            import { Config } from 'yapi-to-typescript'
 
-            const cliConfig: CliConfig = {
-              typesOnly: false,
-              serverConfigs: [
-                {
-                  serverUrl: 'http://foo.bar',
-                  prodEnvName: 'production',
-                  outputFilePath: 'src/api/index.ts',
-                  requestFunctionFilePath: 'src/api/request.ts',
-                  dataKey: 'data',
-                  projects: [
-                    {
-                      token: 'hello',
-                      categories: [
-                        {
-                          id: 50,
-                          getRequestFunctionName(interfaceInfo, changeCase) {
-                            return changeCase.camelCase(
-                              interfaceInfo.parsedPath.name,
-                            )
-                          },
+            const config: Config = [
+              {
+                serverUrl: 'http://foo.bar',
+                typesOnly: false,
+                prodEnvName: 'production',
+                outputFilePath: 'src/api/index.ts',
+                requestFunctionFilePath: 'src/api/request.ts',
+                dataKey: 'data',
+                projects: [
+                  {
+                    token: 'hello',
+                    categories: [
+                      {
+                        id: 50,
+                        getRequestFunctionName(interfaceInfo, changeCase) {
+                          return changeCase.camelCase(
+                            interfaceInfo.parsedPath.name,
+                          )
                         },
-                      ],
-                    },
-                  ],
-                },
-              ]
-            }
+                      },
+                    ],
+                  },
+                ],
+              },
+            ]
 
-            export default cliConfig
+            export default config
           `.replace(/^ {12}/mg, '').trim()}\n`)
           consola.success('写入配置文件完毕')
           break
@@ -77,8 +75,8 @@ TSNode.register({
           }
           consola.success(`找到配置文件: ${configFile}`)
           try {
-            const cliConfig: CliConfig = require(configFile).default
-            const generator = new Generator(cliConfig)
+            const config: Config = require(configFile).default
+            const generator = new Generator(config)
 
             const spinner = ora('正在获取数据并生成代码...').start()
             const output = await generator.generate()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra'
 import ora from 'ora'
 import path from 'path'
 import prompt from 'prompts'
-import { Config } from './types'
+import { CliConfig } from './types'
 import { Generator } from './Generator'
 
 TSNode.register({
@@ -37,34 +37,37 @@ TSNode.register({
             if (!answers.override) return
           }
           await fs.outputFile(configFile, `${`
-            import { Config } from 'yapi-to-typescript'
+            import { CliConfig } from 'yapi-to-typescript'
 
-            const servers: Config = [
-              {
-                serverUrl: 'http://foo.bar',
-                prodEnvName: 'production',
-                outputFilePath: 'src/api/index.ts',
-                requestFunctionFilePath: 'src/api/request.ts',
-                dataKey: 'data',
-                projects: [
-                  {
-                    token: 'hello',
-                    categories: [
-                      {
-                        id: 50,
-                        getRequestFunctionName(interfaceInfo, changeCase) {
-                          return changeCase.camelCase(
-                            interfaceInfo.parsedPath.name,
-                          )
+            const cliConfig: CliConfig = {
+              typesOnly: false,
+              serverConfigs: [
+                {
+                  serverUrl: 'http://foo.bar',
+                  prodEnvName: 'production',
+                  outputFilePath: 'src/api/index.ts',
+                  requestFunctionFilePath: 'src/api/request.ts',
+                  dataKey: 'data',
+                  projects: [
+                    {
+                      token: 'hello',
+                      categories: [
+                        {
+                          id: 50,
+                          getRequestFunctionName(interfaceInfo, changeCase) {
+                            return changeCase.camelCase(
+                              interfaceInfo.parsedPath.name,
+                            )
+                          },
                         },
-                      },
-                    ],
-                  },
-                ],
-              },
-            ]
+                      ],
+                    },
+                  ],
+                },
+              ]
+            }
 
-            export default servers
+            export default cliConfig
           `.replace(/^ {12}/mg, '').trim()}\n`)
           consola.success('写入配置文件完毕')
           break
@@ -74,8 +77,8 @@ TSNode.register({
           }
           consola.success(`找到配置文件: ${configFile}`)
           try {
-            const config: Config = require(configFile).default
-            const generator = new Generator(config)
+            const cliConfig: CliConfig = require(configFile).default
+            const generator = new Generator(cliConfig)
 
             const spinner = ora('正在获取数据并生成代码...').start()
             const output = await generator.generate()

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,6 +219,13 @@ export type CategoryList = Category[]
  */
 export interface SharedConfig {
   /**
+   * 是否只生成 typescript types，如果是 request 文件将也不会生成
+   *
+   * @default false,
+   * @example false
+   */
+  typesOnly?: boolean,
+  /**
    * 测试环境名称。
    *
    * **用于获取测试环境域名。**
@@ -374,13 +381,7 @@ export type SyntheticalConfig = Partial<(
   }
 )>
 
-/** cli配置。 */
-export type CliConfig = {
-  typesOnly: boolean,
-  serverConfigs: Config,
-}
-
-/** 所有的服务器配置。 */
+/** 配置。 */
 export type Config = ServerConfig | ServerConfig[]
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -377,7 +377,6 @@ export type SyntheticalConfig = Partial<(
     mockUrl: string,
     devUrl: string,
     prodUrl: string,
-    typesOnly: boolean,
   }
 )>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -370,10 +370,17 @@ export type SyntheticalConfig = Partial<(
     mockUrl: string,
     devUrl: string,
     prodUrl: string,
+    typesOnly: boolean,
   }
 )>
 
-/** 配置。 */
+/** cli配置。 */
+export type CliConfig = {
+  typesOnly: boolean,
+  serverConfigs: Config,
+}
+
+/** 所有的服务器配置。 */
 export type Config = ServerConfig | ServerConfig[]
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,10 +219,9 @@ export type CategoryList = Category[]
  */
 export interface SharedConfig {
   /**
-   * 是否只生成 typescript types，如果是 request 文件将也不会生成
+   * 是否只生成接口请求内容和返回内容的 TypeSript 类型，是则请求文件和请求函数都不会生成。
    *
-   * @default false,
-   * @example false
+   * @default false
    */
   typesOnly?: boolean,
   /**

--- a/tests/Generator.test.ts
+++ b/tests/Generator.test.ts
@@ -5,47 +5,53 @@ import { Generator } from '../src/Generator'
 
 const apiDir = path.join(__dirname, '../api')
 
-beforeAll(() => {
+beforeEach(() => {
   fs.ensureDirSync(apiDir)
   fs.emptyDirSync(apiDir)
 })
 
-afterAll(() => {
+beforeEach(() => {
   fs.removeSync(apiDir)
 })
 
-const generator = new Generator({
-  serverUrl: 'http://foo.bar',
-  prodEnvName: 'production',
-  outputFilePath: 'api/index.ts',
-  requestFunctionFilePath: 'api/request.ts',
-  projects: [
-    {
-      token: 'hello',
-      categories: [
+const generatorFactory = (typesOnly: boolean) => {
+  return new Generator({
+    typesOnly,
+    serverConfigs: {
+      serverUrl: 'http://foo.bar',
+      prodEnvName: 'production',
+      outputFilePath: 'api/index.ts',
+      requestFunctionFilePath: 'api/request.ts',
+      projects: [
         {
-          id: 58,
-          preproccessInterface(ii) {
-            ii.path += '_test'
-            return ii
-          },
-          getRequestFunctionName(ii, cc) {
-            return cc.camelCase(ii.parsedPath.name)
-          },
-          getRequestDataTypeName(ii, cc) {
-            return `${cc.pascalCase(ii.parsedPath.name)}Request`
-          },
-          getResponseDataTypeName(ii, cc) {
-            return `${cc.pascalCase(ii.parsedPath.name)}Response`
-          },
+          token: 'hello',
+          categories: [
+            {
+              id: 58,
+              preproccessInterface(ii) {
+                ii.path += '_test'
+                return ii
+              },
+              getRequestFunctionName(ii, cc) {
+                return cc.camelCase(ii.parsedPath.name)
+              },
+              getRequestDataTypeName(ii, cc) {
+                return `${cc.pascalCase(ii.parsedPath.name)}Request`
+              },
+              getResponseDataTypeName(ii, cc) {
+                return `${cc.pascalCase(ii.parsedPath.name)}Response`
+              },
+            },
+          ],
         },
       ],
     },
-  ],
-})
+  })
+}
 
 describe('Generator', () => {
   test('正确生成代码并写入文件', async () => {
+    const generator = generatorFactory(false)
     const output = await generator.generate()
     forOwn(output, ({ content }) => {
       expect(content).toMatchSnapshot()
@@ -55,6 +61,20 @@ describe('Generator', () => {
     forOwn(output, ({ requestFilePath }, outputFilePath) => {
       expect(fs.readFileSync(outputFilePath).toString()).toMatchSnapshot()
       expect(fs.readFileSync(requestFilePath).toString()).toMatchSnapshot()
+    })
+  })
+
+  test('只生成类型代码并写入文件', async () => {
+    const generator = generatorFactory(true)
+    const output = await generator.generate()
+    forOwn(output, ({ content }) => {
+      expect(content).toMatchSnapshot()
+    })
+
+    await generator.write(output)
+    forOwn(output, ({ requestFilePath }, outputFilePath) => {
+      expect(fs.readFileSync(outputFilePath).toString()).toMatchSnapshot()
+      expect(fs.existsSync(requestFilePath)).toBe(false)
     })
   })
 })

--- a/tests/Generator.test.ts
+++ b/tests/Generator.test.ts
@@ -16,36 +16,34 @@ beforeEach(() => {
 
 const generatorFactory = (typesOnly: boolean) => {
   return new Generator({
+    serverUrl: 'http://foo.bar',
     typesOnly,
-    serverConfigs: {
-      serverUrl: 'http://foo.bar',
-      prodEnvName: 'production',
-      outputFilePath: 'api/index.ts',
-      requestFunctionFilePath: 'api/request.ts',
-      projects: [
-        {
-          token: 'hello',
-          categories: [
-            {
-              id: 58,
-              preproccessInterface(ii) {
-                ii.path += '_test'
-                return ii
-              },
-              getRequestFunctionName(ii, cc) {
-                return cc.camelCase(ii.parsedPath.name)
-              },
-              getRequestDataTypeName(ii, cc) {
-                return `${cc.pascalCase(ii.parsedPath.name)}Request`
-              },
-              getResponseDataTypeName(ii, cc) {
-                return `${cc.pascalCase(ii.parsedPath.name)}Response`
-              },
+    prodEnvName: 'production',
+    outputFilePath: 'api/index.ts',
+    requestFunctionFilePath: 'api/request.ts',
+    projects: [
+      {
+        token: 'hello',
+        categories: [
+          {
+            id: 58,
+            preproccessInterface(ii) {
+              ii.path += '_test'
+              return ii
             },
-          ],
-        },
-      ],
-    },
+            getRequestFunctionName(ii, cc) {
+              return cc.camelCase(ii.parsedPath.name)
+            },
+            getRequestDataTypeName(ii, cc) {
+              return `${cc.pascalCase(ii.parsedPath.name)}Request`
+            },
+            getResponseDataTypeName(ii, cc) {
+              return `${cc.pascalCase(ii.parsedPath.name)}Response`
+            },
+          },
+        ],
+      },
+    ],
   })
 }
 

--- a/tests/__mocks__/prompts.ts
+++ b/tests/__mocks__/prompts.ts
@@ -1,0 +1,14 @@
+let answer: boolean = false;
+
+// @ts-ignore
+const prompts = async (question: {
+  type: string,
+  name: string,
+  message: string,
+}) => ({ [question.name]: answer })
+
+prompts.setAnswer = (val: boolean) => {
+  answer = val
+}
+
+module.exports = prompts

--- a/tests/__mocks__/request-promise-native.ts
+++ b/tests/__mocks__/request-promise-native.ts
@@ -1,5 +1,5 @@
 const request = {
-  get: url => (
+  get: (url: string) => (
     url.endsWith('/api/plugin/export')
       ? [
         {

--- a/tests/__snapshots__/Generator.test.ts.snap
+++ b/tests/__snapshots__/Generator.test.ts.snap
@@ -1,5 +1,415 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Generator 只生成类型代码并写入文件 1`] = `
+Array [
+  "
+
+
+/**
+ * 接口 **DELETE 方法** 的 **请求类型**
+ */
+export interface DeleteMethodTestRequest {
+  /**
+   * ID
+   */
+  id: string;
+}
+
+/**
+ * 接口 **DELETE 方法** 的 **返回类型**
+ */
+export interface DeleteMethodTestResponse {}
+
+
+/**
+ * 接口 **GET 方法** 的 **请求类型**
+ */
+export interface GetMethodTestRequest {
+  /**
+   * X 值
+   */
+  x: string;
+  /**
+   * Y 值
+   */
+  y?: string;
+}
+
+/**
+ * 接口 **GET 方法** 的 **返回类型**
+ */
+export interface GetMethodTestResponse {
+  /**
+   * 结果
+   */
+  result: number;
+}
+
+
+/**
+ * 接口 **JSON5 响应** 的 **请求类型**
+ */
+export interface Json5ResponseTestRequest {}
+
+/**
+ * 接口 **JSON5 响应** 的 **返回类型**
+ */
+export interface Json5ResponseTestResponse {
+  id?: number;
+  age?: string;
+  name?: string;
+}
+
+
+/**
+ * 接口 **JSON5 请求** 的 **请求类型**
+ */
+export interface Json5RequestTestRequest {
+  id: number;
+  name: string;
+  likes: {}[];
+}
+
+/**
+ * 接口 **JSON5 请求** 的 **返回类型**
+ */
+export interface Json5RequestTestResponse {}
+
+
+/**
+ * 接口 **POST 方法** 的 **请求类型**
+ */
+export interface PostMethodTestRequest {
+  /**
+   * 页码
+   */
+  page: number;
+  /**
+   * 每页数量
+   */
+  limit: number;
+  /**
+   * 关键词
+   */
+  keyword?: string;
+}
+
+/**
+ * 接口 **POST 方法** 的 **返回类型**
+ */
+export interface PostMethodTestResponse {
+  /**
+   * 列表
+   */
+  list: {
+    /**
+     * 姓名
+     */
+    name: string;
+  }[];
+}
+
+
+/**
+ * 接口 **PUT 方法** 的 **请求类型**
+ */
+export interface PutMethodTestRequest {
+  /**
+   * X 值
+   */
+  x: string;
+}
+
+/**
+ * 接口 **PUT 方法** 的 **返回类型**
+ */
+export interface PutMethodTestResponse {
+  /**
+   * 错误
+   */
+  err: number;
+  /**
+   * 错误详情
+   */
+  msg: string;
+  /**
+   * 数据
+   */
+  data?: {};
+}
+
+
+/**
+ * 接口 **dataKey 例子** 的 **请求类型**
+ */
+export interface DataKeyExampleTestRequest {
+  /**
+   * X 值
+   */
+  x: string;
+}
+
+/**
+ * 接口 **dataKey 例子** 的 **返回类型**
+ */
+export interface DataKeyExampleTestResponse {
+  /**
+   * 错误
+   */
+  err: number;
+  /**
+   * 错误详情
+   */
+  msg: string;
+  /**
+   * 数据
+   */
+  data?: {
+    /**
+     * 成功啦
+     */
+    success: boolean;
+  };
+}
+
+
+/**
+ * 接口 **没返回数据** 的 **请求类型**
+ */
+export interface NoResponseDataTestRequest {}
+
+/**
+ * 接口 **没返回数据** 的 **返回类型**
+ */
+export interface NoResponseDataTestResponse {}
+
+
+/**
+ * 接口 **空返回数据** 的 **请求类型**
+ */
+export interface EmptyResponseTestRequest {}
+
+/**
+ * 接口 **空返回数据** 的 **返回类型**
+ */
+export interface EmptyResponseTestResponse {}
+
+
+/**
+ * 接口 **返回 raw** 的 **请求类型**
+ */
+export interface RawResponseTestRequest {}
+
+/**
+ * 接口 **返回 raw** 的 **返回类型**
+ */
+export type RawResponseTestResponse = any",
+]
+`;
+
+exports[`Generator 只生成类型代码并写入文件 2`] = `
+"/**
+ * 接口 **DELETE 方法** 的 **请求类型**
+ */
+export interface DeleteMethodTestRequest {
+  /**
+   * ID
+   */
+  id: string;
+}
+
+/**
+ * 接口 **DELETE 方法** 的 **返回类型**
+ */
+export interface DeleteMethodTestResponse {}
+
+
+/**
+ * 接口 **GET 方法** 的 **请求类型**
+ */
+export interface GetMethodTestRequest {
+  /**
+   * X 值
+   */
+  x: string;
+  /**
+   * Y 值
+   */
+  y?: string;
+}
+
+/**
+ * 接口 **GET 方法** 的 **返回类型**
+ */
+export interface GetMethodTestResponse {
+  /**
+   * 结果
+   */
+  result: number;
+}
+
+
+/**
+ * 接口 **JSON5 响应** 的 **请求类型**
+ */
+export interface Json5ResponseTestRequest {}
+
+/**
+ * 接口 **JSON5 响应** 的 **返回类型**
+ */
+export interface Json5ResponseTestResponse {
+  id?: number;
+  age?: string;
+  name?: string;
+}
+
+
+/**
+ * 接口 **JSON5 请求** 的 **请求类型**
+ */
+export interface Json5RequestTestRequest {
+  id: number;
+  name: string;
+  likes: {}[];
+}
+
+/**
+ * 接口 **JSON5 请求** 的 **返回类型**
+ */
+export interface Json5RequestTestResponse {}
+
+
+/**
+ * 接口 **POST 方法** 的 **请求类型**
+ */
+export interface PostMethodTestRequest {
+  /**
+   * 页码
+   */
+  page: number;
+  /**
+   * 每页数量
+   */
+  limit: number;
+  /**
+   * 关键词
+   */
+  keyword?: string;
+}
+
+/**
+ * 接口 **POST 方法** 的 **返回类型**
+ */
+export interface PostMethodTestResponse {
+  /**
+   * 列表
+   */
+  list: {
+    /**
+     * 姓名
+     */
+    name: string;
+  }[];
+}
+
+
+/**
+ * 接口 **PUT 方法** 的 **请求类型**
+ */
+export interface PutMethodTestRequest {
+  /**
+   * X 值
+   */
+  x: string;
+}
+
+/**
+ * 接口 **PUT 方法** 的 **返回类型**
+ */
+export interface PutMethodTestResponse {
+  /**
+   * 错误
+   */
+  err: number;
+  /**
+   * 错误详情
+   */
+  msg: string;
+  /**
+   * 数据
+   */
+  data?: {};
+}
+
+
+/**
+ * 接口 **dataKey 例子** 的 **请求类型**
+ */
+export interface DataKeyExampleTestRequest {
+  /**
+   * X 值
+   */
+  x: string;
+}
+
+/**
+ * 接口 **dataKey 例子** 的 **返回类型**
+ */
+export interface DataKeyExampleTestResponse {
+  /**
+   * 错误
+   */
+  err: number;
+  /**
+   * 错误详情
+   */
+  msg: string;
+  /**
+   * 数据
+   */
+  data?: {
+    /**
+     * 成功啦
+     */
+    success: boolean;
+  };
+}
+
+
+/**
+ * 接口 **没返回数据** 的 **请求类型**
+ */
+export interface NoResponseDataTestRequest {}
+
+/**
+ * 接口 **没返回数据** 的 **返回类型**
+ */
+export interface NoResponseDataTestResponse {}
+
+
+/**
+ * 接口 **空返回数据** 的 **请求类型**
+ */
+export interface EmptyResponseTestRequest {}
+
+/**
+ * 接口 **空返回数据** 的 **返回类型**
+ */
+export interface EmptyResponseTestResponse {}
+
+
+/**
+ * 接口 **返回 raw** 的 **请求类型**
+ */
+export interface RawResponseTestRequest {}
+
+/**
+ * 接口 **返回 raw** 的 **返回类型**
+ */
+export type RawResponseTestResponse = any
+"
+`;
+
 exports[`Generator 正确生成代码并写入文件 1`] = `
 Array [
   "const mockUrl_0_0_0 = \\"http://foo.bar/mock/32\\" as any

--- a/tests/__snapshots__/cli.test.ts.snap
+++ b/tests/__snapshots__/cli.test.ts.snap
@@ -1,72 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cli 检查到已有配置，可以选择覆盖 1`] = `
-"import { CliConfig } from 'yapi-to-typescript'
+"import { Config } from 'yapi-to-typescript'
 
-const cliConfig: CliConfig = {
-  typesOnly: false,
-  serverConfigs: [
-    {
-      serverUrl: 'http://foo.bar',
-      prodEnvName: 'production',
-      outputFilePath: 'src/api/index.ts',
-      requestFunctionFilePath: 'src/api/request.ts',
-      dataKey: 'data',
-      projects: [
-        {
-          token: 'hello',
-          categories: [
-            {
-              id: 50,
-              getRequestFunctionName(interfaceInfo, changeCase) {
-                return changeCase.camelCase(
-                  interfaceInfo.parsedPath.name,
-                )
-              },
+const config: Config = [
+  {
+    serverUrl: 'http://foo.bar',
+    typesOnly: false,
+    prodEnvName: 'production',
+    outputFilePath: 'src/api/index.ts',
+    requestFunctionFilePath: 'src/api/request.ts',
+    dataKey: 'data',
+    projects: [
+      {
+        token: 'hello',
+        categories: [
+          {
+            id: 50,
+            getRequestFunctionName(interfaceInfo, changeCase) {
+              return changeCase.camelCase(
+                interfaceInfo.parsedPath.name,
+              )
             },
-          ],
-        },
-      ],
-    },
-  ]
-}
+          },
+        ],
+      },
+    ],
+  },
+]
 
-export default cliConfig
+export default config
 "
 `;
 
 exports[`cli 正确初始化配置文件 & 生成结果 1`] = `
-"import { CliConfig } from 'yapi-to-typescript'
+"import { Config } from 'yapi-to-typescript'
 
-const cliConfig: CliConfig = {
-  typesOnly: false,
-  serverConfigs: [
-    {
-      serverUrl: 'http://foo.bar',
-      prodEnvName: 'production',
-      outputFilePath: 'src/api/index.ts',
-      requestFunctionFilePath: 'src/api/request.ts',
-      dataKey: 'data',
-      projects: [
-        {
-          token: 'hello',
-          categories: [
-            {
-              id: 50,
-              getRequestFunctionName(interfaceInfo, changeCase) {
-                return changeCase.camelCase(
-                  interfaceInfo.parsedPath.name,
-                )
-              },
+const config: Config = [
+  {
+    serverUrl: 'http://foo.bar',
+    typesOnly: false,
+    prodEnvName: 'production',
+    outputFilePath: 'src/api/index.ts',
+    requestFunctionFilePath: 'src/api/request.ts',
+    dataKey: 'data',
+    projects: [
+      {
+        token: 'hello',
+        categories: [
+          {
+            id: 50,
+            getRequestFunctionName(interfaceInfo, changeCase) {
+              return changeCase.camelCase(
+                interfaceInfo.parsedPath.name,
+              )
             },
-          ],
-        },
-      ],
-    },
-  ]
-}
+          },
+        ],
+      },
+    ],
+  },
+]
 
-export default cliConfig
+export default config
 "
 `;
 

--- a/tests/__snapshots__/cli.test.ts.snap
+++ b/tests/__snapshots__/cli.test.ts.snap
@@ -1,34 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cli 正确初始化配置文件 & 生成结果 1`] = `
-"import { Config } from 'yapi-to-typescript'
+exports[`cli 检查到已有配置，可以选择覆盖 1`] = `
+"import { CliConfig } from 'yapi-to-typescript'
 
-const servers: Config = [
-  {
-    serverUrl: 'http://foo.bar',
-    prodEnvName: 'production',
-    outputFilePath: 'src/api/index.ts',
-    requestFunctionFilePath: 'src/api/request.ts',
-    dataKey: 'data',
-    projects: [
-      {
-        token: 'hello',
-        categories: [
-          {
-            id: 50,
-            getRequestFunctionName(interfaceInfo, changeCase) {
-              return changeCase.camelCase(
-                interfaceInfo.parsedPath.name,
-              )
+const cliConfig: CliConfig = {
+  typesOnly: false,
+  serverConfigs: [
+    {
+      serverUrl: 'http://foo.bar',
+      prodEnvName: 'production',
+      outputFilePath: 'src/api/index.ts',
+      requestFunctionFilePath: 'src/api/request.ts',
+      dataKey: 'data',
+      projects: [
+        {
+          token: 'hello',
+          categories: [
+            {
+              id: 50,
+              getRequestFunctionName(interfaceInfo, changeCase) {
+                return changeCase.camelCase(
+                  interfaceInfo.parsedPath.name,
+                )
+              },
             },
-          },
-        ],
-      },
-    ],
-  },
-]
+          ],
+        },
+      ],
+    },
+  ]
+}
 
-export default servers
+export default cliConfig
+"
+`;
+
+exports[`cli 正确初始化配置文件 & 生成结果 1`] = `
+"import { CliConfig } from 'yapi-to-typescript'
+
+const cliConfig: CliConfig = {
+  typesOnly: false,
+  serverConfigs: [
+    {
+      serverUrl: 'http://foo.bar',
+      prodEnvName: 'production',
+      outputFilePath: 'src/api/index.ts',
+      requestFunctionFilePath: 'src/api/request.ts',
+      dataKey: 'data',
+      projects: [
+        {
+          token: 'hello',
+          categories: [
+            {
+              id: 50,
+              getRequestFunctionName(interfaceInfo, changeCase) {
+                return changeCase.camelCase(
+                  interfaceInfo.parsedPath.name,
+                )
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ]
+}
+
+export default cliConfig
 "
 `;
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -39,4 +39,42 @@ describe('cli', () => {
     expect(fs.readFileSync(generatedApiFile).toString()).toMatchSnapshot()
     expect(fs.readFileSync(generatedRequestFile).toString()).toMatchSnapshot()
   })
+
+  test('检查到已有配置，可以选择覆盖', async () => {
+    process.chdir(targetDir)
+
+    process.argv[2] = 'init'
+    await import('../src/cli')
+    await sleep(500)
+    fs.writeFileSync(generatedConfigFile, 'error data')
+
+    jest.resetModules()
+    jest.mock('prompts')
+
+
+    require('prompts').setAnswer(true)
+    process.argv[2] = 'init'
+    await import('../src/cli')
+    await sleep(500)
+    expect(fs.readFileSync(generatedConfigFile).toString()).toMatchSnapshot()
+  })
+
+  test('检查到已有配置，选择不做任何操作', async () => {
+    process.chdir(targetDir)
+
+    process.argv[2] = 'init'
+    await import('../src/cli')
+    await sleep(500)
+    fs.writeFileSync(generatedConfigFile, 'error data')
+
+    jest.resetModules()
+    jest.mock('prompts')
+
+
+    require('prompts').setAnswer(false)
+    process.argv[2] = 'init'
+    await import('../src/cli')
+    await sleep(500)
+    expect(fs.readFileSync(generatedConfigFile).toString()).toBe('error data')
+  })
 })


### PR DESCRIPTION
# Why

1. 对于一些原有的项目，仅支持type是最好的解决方案

# Change

1. 增加了typesOnly选项

在SharedConfig 中加入typesOnly
```ts
export interface SharedConfig {
  typesOnly?: boolean,
  // ...
}
```

实际产出内容见： `/tests/__snapshots__/Generator.test.ts.snap#L3-L411`

2. 增加了一些遗漏的测试，以及typesOnly相关的测试