### PR TITLE
feat: add requestToolConfig，接口新增请求工具参数options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra'
 import ora from 'ora'
 import path from 'path'
 import prompt from 'prompts'
-import {Config} from './types'
+import {Config, GeneratorConfig, RequestToolConfig} from './types'
 import {dedent} from 'vtils'
 import {Generator} from './Generator'
 
@@ -88,7 +88,12 @@ export async function run(cwd: string = process.cwd()) {
     consola.success(`找到配置文件: ${configFile}`)
     try {
       const config: Config = require(configFile).default
-      const generator = new Generator(config, {cwd})
+      const requestToolConfig: RequestToolConfig = require(configFile).requestToolConfig
+      const generatorConfig: GeneratorConfig = {
+        yapiConfig: config,
+        requestToolConfig,
+      }
+      const generator = new Generator(generatorConfig, {cwd})
 
       const spinner = ora('正在获取数据并生成代码...').start()
       const output = await generator.generate()

--- a/src/types.ts
+++ b/src/types.ts
@@ -450,10 +450,28 @@ export type SyntheticalConfig = Partial<(
     devUrl: string,
     prodUrl: string,
   }
+  & RequestToolConfig
 )>
+
+/** 请求工具配置。 */
+export type RequestToolConfig = {
+  /**
+   * 请求工具类型定义路径。
+   */
+  packagePath: string,
+  /**
+   * 请求工具Options类型名称。
+   */
+  optionsType: string,
+}
 
 /** 配置。 */
 export type Config = ServerConfig | ServerConfig[]
+
+export type GeneratorConfig = {
+  yapiConfig: Config,
+  requestToolConfig?: RequestToolConfig,
+}
 
 /**
  * 请求配置。
@@ -504,6 +522,7 @@ export interface RequestFunctionParams extends RequestConfig {
 export type RequestFunction = (
   /** 参数 */
   params: RequestFunctionParams,
+  options?: any
 ) => Promise<any>
 
 /** 属性定义 */


### PR DESCRIPTION
接口支持请求工具自带参数(对原Config无影响)
## 问题
使用中发现生成的接口请求中只有一个参数，对于不同接口的不同请求配置支持不是很友好，如请求工具umi-request的useCache + ttl等；
解决方法可以去yapi上把请求工具的参数加在具体请求上，业务参数和请求工具参数混合，感觉不是很友好。
## 解决方法
### 新增options参数从接口函数传给request函数实现
每个接口函数都有options参数方便控制。

### 新增配置示例：
`ytt.config.ts`
```TypeScript
import { RequestToolConfig } from 'yapi-to-typescript'
export const requestToolConfig:RequestToolConfig = {
  packagePath: 'umi-request',
  optionsType: 'RequestOptionsInit',
}
```
