### PR TITLE
feat: add requestToolConfig，接口新增请求工具参数options

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import prettier from 'prettier'
 import request from 'request-promise-native'
 import {castArray, dedent, isArray, isEmpty, isFunction, omit} from 'vtils'
-import {CategoryList, Config, ExtendedInterface, Interface, InterfaceList, Method, PropDefinition, RequestBodyType, RequestFormItemType, Required, ResponseBodyType, ServerConfig, SyntheticalConfig} from './types'
+import {CategoryList, ExtendedInterface, GeneratorConfig, Interface, InterfaceList, Method, PropDefinition, RequestBodyType, RequestFormItemType, RequestToolConfig, Required, ResponseBodyType, ServerConfig, SyntheticalConfig} from './types'
 import {formatDate} from '@vtils/date'
 import {getNormalizedRelativePath, jsonSchemaStringToJsonSchema, jsonSchemaToType, jsonToJsonSchema, mockjsTemplateToJsonSchema, propDefinitionsToJsonSchema, throwError} from './utils'
 import {JSONSchema4} from 'json-schema'
@@ -20,24 +20,31 @@ interface OutputFileList {
 
 export class Generator {
   /** 配置 */
-  private config: ServerConfig[] = []
+  private config: {
+    yapiConfig: ServerConfig[],
+    requestToolConfig?: RequestToolConfig,
+  }
 
   /** { 项目标识: 分类列表 } */
   private projectIdToCategoryList: Record<string, CategoryList | undefined> = Object.create(null)
 
   constructor(
-    config: Config,
+    config: GeneratorConfig,
     private options: { cwd: string } = {cwd: process.cwd()},
   ) {
     // config 可能是对象或数组，统一为数组
-    this.config = castArray(config)
+    this.config = {
+      yapiConfig: castArray(config.yapiConfig),
+      requestToolConfig: config.requestToolConfig,
+    }
   }
 
   async generate(): Promise<OutputFileList> {
     const outputFileList: OutputFileList = Object.create(null)
+    const {requestToolConfig} = this.config
 
     await Promise.all(
-      this.config.map(
+      this.config.yapiConfig.map(
         async (serverConfig, serverIndex) => Promise.all(
           serverConfig.projects.map(
             async (projectConfig, projectIndex) => {
@@ -65,6 +72,7 @@ export class Generator {
                           ...projectConfig,
                           ...categoryConfig,
                           mockUrl: projectInfo.getMockUrl(),
+                          ...requestToolConfig,
                         }
                         syntheticalConfig.devUrl = projectInfo.getDevUrl(syntheticalConfig.devEnvName!)
                         syntheticalConfig.prodUrl = projectInfo.getProdUrl(syntheticalConfig.prodEnvName!)
@@ -131,6 +139,7 @@ export class Generator {
   }
 
   async write(outputFileList: OutputFileList) {
+    const {requestToolConfig: {packagePath = '', optionsType = ''} = {}} = this.config
     return Promise.all(
       Object.keys(outputFileList).map(async outputFilePath => {
         const {content, requestFilePath, syntheticalConfig} = outputFileList[outputFilePath]
@@ -141,6 +150,7 @@ export class Generator {
             requestFilePath,
             dedent`
               import { RequestFunction } from 'yapi-to-typescript'
+              ${packagePath && optionsType ? `import { ${optionsType} } from '${packagePath}'` : ''}
 
               /** 是否是生产环境 */
               const isProd = false
@@ -175,7 +185,7 @@ export class Generator {
                 data,
                 /** 请求文件数据 */
                 fileData
-              }): Promise<any> => {
+              }${packagePath && optionsType ? `, options?: ${optionsType}` : ''}): Promise<any> => {
                 return new Promise((resolve, reject) => {
                   /** 请求地址 */
                   const url = \`\${isProd ? prodUrl : mockUrl}\${path}\`
@@ -210,6 +220,7 @@ export class Generator {
           ${syntheticalConfig.typesOnly ? content.join('\n\n').trim() : dedent`
             // @ts-ignore
             import { Method, RequestBodyType, ResponseBodyType, RequestConfig, FileData, prepare } from 'yapi-to-typescript'
+            ${packagePath && optionsType ? `import { ${optionsType} } from '${packagePath}'` : ''}
             ${!syntheticalConfig.reactHooks || !syntheticalConfig.reactHooks.enable ? '' : dedent`
               // @ts-ignore
               import { createApiHook } from 'yapi-to-typescript'
@@ -522,6 +533,7 @@ export class Generator {
       .filter(item => !isEmpty(item.value))
       .map(item => `* @${item.label} ${castArray(item.value).join(', ')}`)
       .join('\n')
+    const {packagePath, optionsType} = syntheticalConfig
 
     return dedent`
       /**
@@ -544,8 +556,8 @@ export class Generator {
          *
          ${interfaceExtraComments}
          */
-        export function ${requestFunctionName}(requestData${isRequestDataOptional ? '?' : ''}: ${requestDataTypeName}): Promise<${responseDataTypeName}> {
-          return request(prepare(${requestFunctionName}.requestConfig, requestData))
+        export function ${requestFunctionName}(requestData${isRequestDataOptional ? '?' : ''}: ${requestDataTypeName}${packagePath && optionsType ? `, options?: ${optionsType}` : ''}): Promise<${responseDataTypeName}> {
+          return request(prepare(${requestFunctionName}.requestConfig, requestData)${packagePath && optionsType ? `, options` : ''})
         }
 
         /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra'
 import ora from 'ora'
 import path from 'path'
 import prompt from 'prompts'
-import {Config} from './types'
+import {Config, GeneratorConfig, RequestToolConfig} from './types'
 import {dedent} from 'vtils'
 import {Generator} from './Generator'
 
@@ -88,7 +88,12 @@ export async function run(cwd: string = process.cwd()) {
     consola.success(`找到配置文件: ${configFile}`)
     try {
       const config: Config = require(configFile).default
-      const generator = new Generator(config, {cwd})
+      const requestToolConfig: RequestToolConfig = require(configFile).requestToolConfig
+      const generatorConfig: GeneratorConfig = {
+        yapiConfig: config,
+        requestToolConfig,
+      }
+      const generator = new Generator(generatorConfig, {cwd})
 
       const spinner = ora('正在获取数据并生成代码...').start()
       const output = await generator.generate()

--- a/src/types.ts
+++ b/src/types.ts
@@ -450,10 +450,28 @@ export type SyntheticalConfig = Partial<(
     devUrl: string,
     prodUrl: string,
   }
+  & RequestToolConfig
 )>
+
+/** 请求工具配置。 */
+export type RequestToolConfig = {
+  /**
+   * 请求工具类型定义路径。
+   */
+  packagePath: string,
+  /**
+   * 请求工具Options类型名称。
+   */
+  optionsType: string,
+}
 
 /** 配置。 */
 export type Config = ServerConfig | ServerConfig[]
+
+export type GeneratorConfig = {
+  yapiConfig: Config,
+  requestToolConfig?: RequestToolConfig,
+}
 
 /**
  * 请求配置。
@@ -504,6 +522,7 @@ export interface RequestFunctionParams extends RequestConfig {
 export type RequestFunction = (
   /** 参数 */
   params: RequestFunctionParams,
+  options?: any
 ) => Promise<any>
 
 /** 属性定义 */


### PR DESCRIPTION
接口支持请求工具自带参数(对原Config无影响)

## 问题
使用中发现生成的接口请求中只有一个参数，对于不同接口的不同请求配置支持不是很友好，如请求工具umi-request的useCache + ttl等；
解决方法可以去yapi上把请求工具的参数加在具体请求上，业务参数和请求工具参数混合，感觉不是很友好。

## 解决方法
### 新增options参数从接口函数传给request函数实现
每个接口函数都有options参数方便控制。

### 新增配置示例：
`ytt.config.ts`
```TypeScript
import { RequestToolConfig } from 'yapi-to-typescript'
export const requestToolConfig:RequestToolConfig = {
  packagePath: 'umi-request',
  optionsType: 'RequestOptionsInit',
}
```