### PR TITLE
fix: ignore jsonSchema maxItems, minItems

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,8 @@ export function processJsonSchema<T extends JSONSchema4>(jsonSchema: T): T {
   // 去除 title 和 id，防止 json-schema-to-typescript 提取它们作为接口名
   delete jsonSchema.title
   delete jsonSchema.id
+  
+  // 忽略条目个数限制
   delete jsonSchema.minItems
   delete jsonSchema.maxItems
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,8 @@ export function processJsonSchema<T extends JSONSchema4>(jsonSchema: T): T {
   // 去除 title 和 id，防止 json-schema-to-typescript 提取它们作为接口名
   delete jsonSchema.title
   delete jsonSchema.id
+  delete jsonSchema.minItems
+  delete jsonSchema.maxItems
 
   // 将 additionalProperties 设为 false
   jsonSchema.additionalProperties = false


### PR DESCRIPTION
问题
![image](https://user-images.githubusercontent.com/12288710/74210536-1a336480-4cc7-11ea-928c-cd6dde4e717c.png)
数组mock经常会用到配置长度，目前会在接口返回中体现，可能会影响接口返回、同时生成太多无意义代码，个人感觉yapi中配置的这个长度应该只用来方便mock数据
![image](https://user-images.githubusercontent.com/12288710/74210890-88c4f200-4cc8-11ea-8bd2-93ce9a5542cc.png)

考虑忽略下minItems和maxItems？

参考：
-  [json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript/blob/master/CHANGELOG.md) 7.0.0加入了minItems、maxItems
- https://github.com/bcherny/json-schema-to-typescript/issues/250
