### PR TITLE
fix: not-generator-file-on-window

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -532,10 +532,11 @@ export class Generator {
 
   async tsc(file: string) {
     return new Promise(resolve => {
+      // add this to fix bug that not-generator-file-on-window  
+      const command =  `${require('os').platform() === 'win32' ? 'node ' : ''}${require.resolve(`typescript/bin/tsc`)}`;
+
       exec(
-        `${require.resolve(
-          'typescript/bin/tsc',
-        )} --target ES2019 --module ESNext --jsx preserve --declaration --esModuleInterop ${file}`,
+        `${command} --target ES2019 --module ESNext --jsx preserve --declaration --esModuleInterop ${file}`,
         {
           cwd: this.options.cwd,
           env: process.env,


### PR DESCRIPTION
问题复现：在 window 下，ytt.config.js 中设置  target: 'javascript', 发觉没有生成 对应的文件 *.js 与 *d.ts，

排查过程：排查定位到是在 line 521 左右
` if (syntheticalConfig.target === 'javascript') {
          await this.tsc(outputFilePath)
          await Promise.all([
            fs.remove(requestFunctionFilePath).catch(noop),
            fs.remove(requestHookMakerFilePath).catch(noop),
            fs.remove(outputFilePath).catch(noop),
          ])
        }`
 this.tsc() 执行不成功，没有将对应的 *.ts  通过 tsc 编译成 *.d.ts 与 *.js 。

原因： `linux 与 macos `都能直接执行 ` require.resolve(`typescript/bin/tsc`) ` 该可执行文件，而 `window ` 的可执行文件是` *.cmd`
故，this.tsc 在 window 执行失败 

demo： https://github.com/yolo-jane/yapi2ts-bug-on-win