### PR TITLE
feat: 增加 tree shacking 标记使摇树优化生效

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -53,6 +53,12 @@ interface OutputFileList {
   }
 }
 
+/**
+ * @see https://webpack.js.org/guides/tree-shaking/#mark-a-function-call-as-side-effect-free
+ * @see https://terser.org/docs/api-reference.html#annotations
+ */
+const COMPRESSOR_TREE_SHAKING_ANNOTATION = '/*#__PURE__*/'
+
 export class Generator {
   /** 配置 */
   private config: ServerConfig[] = []
@@ -887,7 +893,7 @@ export class Generator {
             >>
 
             ${genComment(title => `接口 ${title} 的 **请求配置**`)}
-            const ${requestConfigName}: ${requestConfigTypeName} = {
+            const ${requestConfigName}: ${requestConfigTypeName} = ${COMPRESSOR_TREE_SHAKING_ANNOTATION} {
               mockUrl: mockUrl${categoryUID},
               devUrl: devUrl${categoryUID},
               prodUrl: prodUrl${categoryUID},
@@ -931,7 +937,7 @@ export class Generator {
             }
 
             ${genComment(title => `接口 ${title} 的 **请求函数**`)}
-            export const ${requestFunctionName} = (
+            export const ${requestFunctionName} = ${COMPRESSOR_TREE_SHAKING_ANNOTATION} (
               requestData${
                 isRequestDataOptional ? '?' : ''
               }: ${requestDataTypeName},
@@ -951,7 +957,7 @@ export class Generator {
                 ? ''
                 : dedent`
                   ${genComment(title => `接口 ${title} 的 **React Hook**`)}
-                  export const ${requestHookName} = makeRequestHook<${requestDataTypeName}, ${requestConfigTypeName}, ReturnType<typeof ${requestFunctionName}>>(${requestFunctionName})
+                  export const ${requestHookName} = ${COMPRESSOR_TREE_SHAKING_ANNOTATION} makeRequestHook<${requestDataTypeName}, ${requestConfigTypeName}, ReturnType<typeof ${requestFunctionName}>>(${requestFunctionName})
                 `
             }
           `

--- a/tests/__snapshots__/Generator.test.ts.snap
+++ b/tests/__snapshots__/Generator.test.ts.snap
@@ -64,7 +64,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @更新时间 1610557430
  * @项目ID 11
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -93,7 +93,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @更新时间 1610557430
  * @项目ID 11
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -165,7 +165,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -192,7 +192,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -270,7 +270,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -296,7 +296,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -362,7 +362,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -388,7 +388,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -460,7 +460,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -487,7 +487,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -551,7 +551,7 @@ type Picture_3dDetailTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
+const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -577,7 +577,7 @@ const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-export const picture_3dDetailTest = (
+export const picture_3dDetailTest = /*#__PURE__*/ (
   requestData?: Picture_3dDetailTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -637,7 +637,7 @@ type GetTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-const getTestRequestConfig: GetTestRequestConfig = {
+const getTestRequestConfig: GetTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -663,7 +663,7 @@ const getTestRequestConfig: GetTestRequestConfig = {
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-export const getTest = (
+export const getTest = /*#__PURE__*/ (
   requestData: GetTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -724,7 +724,7 @@ type FormTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-const formTestRequestConfig: FormTestRequestConfig = {
+const formTestRequestConfig: FormTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -750,7 +750,7 @@ const formTestRequestConfig: FormTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-export const formTest = (
+export const formTest = /*#__PURE__*/ (
   requestData: FormTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -820,7 +820,7 @@ type JsonTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-const jsonTestRequestConfig: JsonTestRequestConfig = {
+const jsonTestRequestConfig: JsonTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -846,7 +846,7 @@ const jsonTestRequestConfig: JsonTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-export const jsonTest = (
+export const jsonTest = /*#__PURE__*/ (
   requestData: JsonTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -920,7 +920,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -947,7 +947,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -2174,7 +2174,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2205,7 +2205,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -2270,7 +2270,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2301,7 +2301,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -2356,7 +2356,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2382,7 +2382,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -2458,7 +2461,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2500,7 +2503,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -2574,7 +2577,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2609,7 +2612,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -2680,7 +2683,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2715,7 +2718,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -2791,7 +2794,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2826,7 +2829,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -2886,7 +2892,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -2920,7 +2926,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -2984,7 +2990,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3019,7 +3025,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -3070,7 +3076,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3096,7 +3102,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -3147,7 +3156,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3173,7 +3182,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -3233,7 +3245,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3270,7 +3282,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -3338,7 +3350,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3374,7 +3386,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -3447,7 +3459,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3485,7 +3497,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -3539,7 +3551,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3565,7 +3577,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -3616,7 +3628,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3642,7 +3654,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -3706,7 +3718,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3741,7 +3753,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -3802,7 +3814,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3828,7 +3840,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -3884,7 +3896,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -3915,7 +3927,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -3980,7 +3995,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4006,7 +4021,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4075,7 +4090,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4101,7 +4116,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4160,7 +4175,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4186,7 +4201,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4266,7 +4281,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4292,7 +4307,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4370,7 +4385,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4396,7 +4411,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4471,7 +4486,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4497,7 +4512,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4577,7 +4592,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4603,7 +4618,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4667,7 +4682,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4693,7 +4708,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4761,7 +4776,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4787,7 +4802,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4842,7 +4857,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4868,7 +4883,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -4923,7 +4938,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -4949,7 +4964,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5013,7 +5028,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5039,7 +5054,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5111,7 +5126,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5137,7 +5152,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5214,7 +5229,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5240,7 +5255,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5295,7 +5310,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5321,7 +5336,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5376,7 +5391,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5402,7 +5417,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5470,7 +5485,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5496,7 +5511,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5561,7 +5576,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5587,7 +5602,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5647,7 +5662,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5673,7 +5688,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -5768,7 +5783,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5794,7 +5809,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -5859,7 +5874,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5890,7 +5905,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -5945,7 +5960,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -5982,7 +5997,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -6058,7 +6076,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6084,7 +6102,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -6158,7 +6176,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6201,7 +6219,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -6272,7 +6290,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6307,7 +6325,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -6383,7 +6401,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6424,7 +6442,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -6484,7 +6505,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6510,7 +6531,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -6574,7 +6595,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6600,7 +6621,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -6651,7 +6672,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6677,7 +6698,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -6728,7 +6752,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6754,7 +6778,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -6814,7 +6841,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6840,7 +6867,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -6908,7 +6935,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -6934,7 +6961,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -7007,7 +7034,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7033,7 +7060,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -7087,7 +7114,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7113,7 +7140,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -7164,7 +7191,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7190,7 +7217,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -7254,7 +7281,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7280,7 +7307,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -7341,7 +7368,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7388,7 +7415,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -7444,7 +7471,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7470,7 +7497,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -7535,7 +7565,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7561,7 +7591,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -7630,7 +7660,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7656,7 +7686,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -7715,7 +7745,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7741,7 +7771,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -7821,7 +7851,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7847,7 +7877,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -7925,7 +7955,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -7951,7 +7981,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8026,7 +8056,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8052,7 +8082,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8132,7 +8162,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8158,7 +8188,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8222,7 +8252,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8248,7 +8278,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8316,7 +8346,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8342,7 +8372,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8397,7 +8427,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8423,7 +8453,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8478,7 +8508,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8504,7 +8534,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8568,7 +8598,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8594,7 +8624,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8666,7 +8696,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8692,7 +8722,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8769,7 +8799,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8795,7 +8825,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8850,7 +8880,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8876,7 +8906,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -8931,7 +8961,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -8957,7 +8987,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -9025,7 +9055,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9051,7 +9081,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -9116,7 +9146,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9142,7 +9172,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -9202,7 +9232,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9228,7 +9258,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -9298,7 +9328,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9325,7 +9355,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -9422,7 +9452,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -9448,7 +9478,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -9513,7 +9543,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -9539,7 +9569,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -9634,7 +9664,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__projectA__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9660,7 +9690,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__projectA__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -9725,7 +9755,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9751,7 +9781,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__projectA__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -9806,7 +9836,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9832,7 +9862,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__projectA__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -9908,7 +9941,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -9934,7 +9967,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__projectA__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -10008,7 +10041,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10034,7 +10067,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__projectA__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -10105,7 +10138,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__projectA__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10131,7 +10164,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__projectA__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -10207,7 +10240,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__projectA__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10233,7 +10266,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__projectA__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -10293,7 +10329,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10319,7 +10355,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__projectA__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -10383,7 +10419,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10409,7 +10445,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectA__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -10460,7 +10496,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10486,7 +10522,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__projectA__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -10537,7 +10576,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10563,7 +10602,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__projectA__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -10623,7 +10665,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10649,7 +10691,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectA__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -10717,7 +10759,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10743,7 +10785,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -10816,7 +10858,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10842,7 +10884,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -10896,7 +10938,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10922,7 +10964,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__projectA__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -10973,7 +11015,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -10999,7 +11041,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__projectA__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -11063,7 +11105,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -11089,7 +11131,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__projectA__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -11150,7 +11192,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -11176,7 +11218,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__projectA__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -11232,7 +11274,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectA__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -11258,7 +11300,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__projectA__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -11319,7 +11364,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__projectB__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -11345,7 +11390,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__projectB__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -11410,7 +11455,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -11436,7 +11481,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__projectB__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -11491,7 +11536,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -11517,7 +11562,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__projectB__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -11593,7 +11641,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -11619,7 +11667,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__projectB__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -11693,7 +11741,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -11719,7 +11767,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__projectB__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -11790,7 +11838,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__projectB__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -11816,7 +11864,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__projectB__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -11892,7 +11940,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__projectB__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -11918,7 +11966,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__projectB__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -11978,7 +12029,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12004,7 +12055,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__projectB__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -12068,7 +12119,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12094,7 +12145,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectB__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -12145,7 +12196,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12171,7 +12222,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__projectB__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -12222,7 +12276,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12248,7 +12302,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__projectB__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -12308,7 +12365,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12334,7 +12391,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectB__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -12402,7 +12459,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12428,7 +12485,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -12501,7 +12558,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12527,7 +12584,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -12581,7 +12638,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12607,7 +12664,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__projectB__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -12658,7 +12715,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12684,7 +12741,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__projectB__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -12748,7 +12805,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12774,7 +12831,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__projectB__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -12835,7 +12892,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12861,7 +12918,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__projectB__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -12917,7 +12974,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__projectB__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -12943,7 +13000,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__projectB__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -13046,7 +13106,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__projectA__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13072,7 +13132,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__projectA__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13141,7 +13201,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13167,7 +13227,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__projectA__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13226,7 +13286,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13252,7 +13312,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__projectA__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13332,7 +13392,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13358,7 +13418,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__projectA__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13436,7 +13496,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13462,7 +13522,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__projectA__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13537,7 +13597,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__projectA__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13563,7 +13623,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__projectA__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13643,7 +13703,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__projectA__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13669,7 +13729,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__projectA__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13733,7 +13793,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13759,7 +13819,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__projectA__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13827,7 +13887,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13853,7 +13913,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectA__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13908,7 +13968,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -13934,7 +13994,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__projectA__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -13989,7 +14049,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14015,7 +14075,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__projectA__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14079,7 +14139,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14105,7 +14165,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectA__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14177,7 +14237,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14203,7 +14263,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14280,7 +14340,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14306,7 +14366,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__projectA__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14361,7 +14421,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14387,7 +14447,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__projectA__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14442,7 +14502,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14468,7 +14528,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__projectA__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14536,7 +14596,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14562,7 +14622,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__projectA__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14627,7 +14687,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14653,7 +14713,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__projectA__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14713,7 +14773,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectA__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -14739,7 +14799,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__projectA__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14803,7 +14863,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__projectB__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -14829,7 +14889,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__projectB__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14898,7 +14958,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -14924,7 +14984,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__projectB__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -14983,7 +15043,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15009,7 +15069,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__projectB__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15089,7 +15149,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15115,7 +15175,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__projectB__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15193,7 +15253,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15219,7 +15279,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__projectB__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15294,7 +15354,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__projectB__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15320,7 +15380,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__projectB__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15400,7 +15460,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__projectB__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15426,7 +15486,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__projectB__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15490,7 +15550,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15516,7 +15576,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__projectB__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15584,7 +15644,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15610,7 +15670,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectB__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15665,7 +15725,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15691,7 +15751,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__projectB__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15746,7 +15806,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15772,7 +15832,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__projectB__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15836,7 +15896,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15862,7 +15922,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__projectB__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -15934,7 +15994,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -15960,7 +16020,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -16037,7 +16097,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -16063,7 +16123,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__projectB__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -16118,7 +16178,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -16144,7 +16204,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__projectB__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -16199,7 +16259,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -16225,7 +16285,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__projectB__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -16293,7 +16353,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -16319,7 +16379,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__projectB__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -16384,7 +16444,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -16410,7 +16470,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__projectB__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -16470,7 +16530,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__projectB__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_1_0_0,
   devUrl: devUrl_0_1_0_0,
   prodUrl: prodUrl_0_1_0_0,
@@ -16496,7 +16556,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__projectB__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -16591,7 +16651,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /i-am-basepath/__with-basepath__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -16617,7 +16677,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /i-am-basepath/__with-basepath__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -16682,7 +16742,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -16708,7 +16768,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -16763,7 +16823,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -16789,7 +16849,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -16865,7 +16928,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -16891,7 +16954,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -16965,7 +17028,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -16991,7 +17054,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -17062,7 +17125,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17088,7 +17151,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -17164,7 +17227,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17190,7 +17253,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -17250,7 +17316,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17276,7 +17342,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -17340,7 +17406,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17366,7 +17432,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -17417,7 +17483,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17443,7 +17509,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -17494,7 +17563,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17520,7 +17589,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -17580,7 +17652,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17606,7 +17678,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -17674,7 +17746,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17700,7 +17772,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -17773,7 +17845,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17799,7 +17871,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -17853,7 +17925,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17879,7 +17951,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -17930,7 +18002,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -17956,7 +18028,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -18020,7 +18092,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18046,7 +18118,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -18107,7 +18179,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18133,7 +18205,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -18189,7 +18261,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18215,7 +18287,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -18318,7 +18393,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /i-am-basepath/__with-basepath__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18344,7 +18419,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /i-am-basepath/__with-basepath__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -18413,7 +18488,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18439,7 +18514,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -18498,7 +18573,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18524,7 +18599,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -18604,7 +18679,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18630,7 +18705,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -18708,7 +18783,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18734,7 +18809,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -18809,7 +18884,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18835,7 +18910,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -18915,7 +18990,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -18941,7 +19016,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /i-am-basepath/__with-basepath__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19005,7 +19080,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19031,7 +19106,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19099,7 +19174,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19125,7 +19200,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19180,7 +19255,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19206,7 +19281,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19261,7 +19336,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19287,7 +19362,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19351,7 +19426,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19377,7 +19452,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19449,7 +19524,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19475,7 +19550,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19552,7 +19627,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19578,7 +19653,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /i-am-basepath/__with-basepath__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19633,7 +19708,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19659,7 +19734,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19714,7 +19789,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19740,7 +19815,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19808,7 +19883,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19834,7 +19909,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19899,7 +19974,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -19925,7 +20000,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -19985,7 +20060,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /i-am-basepath/__with-basepath__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20011,7 +20086,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /i-am-basepath/__with-basepath__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -20102,7 +20177,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20127,7 +20202,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -20188,7 +20263,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20213,7 +20288,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -20264,7 +20339,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20289,7 +20364,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -20361,7 +20439,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20386,7 +20464,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -20456,7 +20534,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20481,7 +20559,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -20548,7 +20626,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20573,7 +20651,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -20645,7 +20723,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20670,7 +20748,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -20726,7 +20807,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20751,7 +20832,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -20811,7 +20892,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20836,7 +20917,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -20883,7 +20964,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20908,7 +20989,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -20955,7 +21039,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -20980,7 +21064,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -21036,7 +21123,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21061,7 +21148,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -21125,7 +21212,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21150,7 +21237,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -21219,7 +21306,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21244,7 +21331,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -21294,7 +21381,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21319,7 +21406,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -21366,7 +21453,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21391,7 +21478,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -21451,7 +21538,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21476,7 +21563,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -21533,7 +21620,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21558,7 +21645,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -21610,7 +21697,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21635,7 +21722,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -21696,7 +21786,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21721,7 +21811,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -21786,7 +21876,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21811,7 +21901,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -21866,7 +21956,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21891,7 +21981,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -21967,7 +22057,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -21992,7 +22082,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22066,7 +22156,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22091,7 +22181,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22162,7 +22252,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22187,7 +22277,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22263,7 +22353,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22288,7 +22378,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22348,7 +22438,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22373,7 +22463,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22437,7 +22527,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22462,7 +22552,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22513,7 +22603,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22538,7 +22628,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22589,7 +22679,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22614,7 +22704,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22674,7 +22764,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22699,7 +22789,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22767,7 +22857,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22792,7 +22882,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22865,7 +22955,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22890,7 +22980,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -22941,7 +23031,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -22966,7 +23056,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -23017,7 +23107,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23042,7 +23132,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -23106,7 +23196,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23131,7 +23221,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -23192,7 +23282,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23217,7 +23307,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -23273,7 +23363,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23298,7 +23388,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -23389,7 +23479,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23414,7 +23504,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -23475,7 +23565,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/getMethod_test\`
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23500,7 +23590,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/getMethod_test\`
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -23551,7 +23641,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/json5Response_test\`
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23576,7 +23666,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/json5Response_test\`
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -23648,7 +23741,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/json5Request_test\`
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23673,7 +23766,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/json5Request_test\`
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -23743,7 +23836,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/postMethod_test\`
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23768,7 +23861,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/postMethod_test\`
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -23835,7 +23928,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/putMethod_test\`
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23860,7 +23953,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/putMethod_test\`
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -23932,7 +24025,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -23957,7 +24050,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -24013,7 +24109,7 @@ type UploadTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/upload_test\`
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24038,7 +24134,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/upload_test\`
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -24098,7 +24194,7 @@ type TestTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test_test\`
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24123,7 +24219,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test_test\`
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -24170,7 +24266,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/noResponseData_test\`
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24195,7 +24291,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/noResponseData_test\`
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -24242,7 +24341,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24267,7 +24366,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -24323,7 +24425,7 @@ type TestTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24348,7 +24450,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -24412,7 +24514,7 @@ type HihihiTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24437,7 +24539,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -24506,7 +24608,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24531,7 +24633,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -24581,7 +24683,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/rawResponse_test\`
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24606,7 +24708,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/rawResponse_test\`
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -24653,7 +24755,7 @@ type HeadersTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/headers_test\`
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24678,7 +24780,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/headers_test\`
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -24738,7 +24840,7 @@ type AvatarTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24763,7 +24865,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -24820,7 +24922,7 @@ type DeepTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24845,7 +24947,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -24897,7 +24999,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -24922,7 +25024,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -24983,7 +25088,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25008,7 +25113,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25073,7 +25178,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/getMethod_test\`
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25098,7 +25203,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/getMethod_test\`
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25153,7 +25258,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/json5Response_test\`
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25178,7 +25283,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/json5Response_test\`
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25254,7 +25359,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/json5Request_test\`
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25279,7 +25384,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/json5Request_test\`
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25353,7 +25458,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/postMethod_test\`
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25378,7 +25483,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/postMethod_test\`
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25449,7 +25554,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/putMethod_test\`
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25474,7 +25579,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/putMethod_test\`
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25550,7 +25655,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25575,7 +25680,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25635,7 +25740,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/upload_test\`
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25660,7 +25765,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/upload_test\`
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25724,7 +25829,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test_test\`
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25749,7 +25854,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test_test\`
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25800,7 +25905,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/noResponseData_test\`
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25825,7 +25930,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/noResponseData_test\`
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25876,7 +25981,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25901,7 +26006,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -25961,7 +26066,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -25986,7 +26091,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26054,7 +26159,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26079,7 +26184,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26152,7 +26257,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26177,7 +26282,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26228,7 +26333,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/rawResponse_test\`
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26253,7 +26358,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/rawResponse_test\`
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26304,7 +26409,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/headers_test\`
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26329,7 +26434,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/headers_test\`
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26393,7 +26498,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26418,7 +26523,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26479,7 +26584,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26504,7 +26609,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26560,7 +26665,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26585,7 +26690,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -26680,7 +26785,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26706,7 +26811,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -26771,7 +26876,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26797,7 +26902,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -26852,7 +26957,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26878,7 +26983,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -26954,7 +27062,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -26980,7 +27088,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -27054,7 +27162,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27080,7 +27188,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -27151,7 +27259,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27177,7 +27285,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -27253,7 +27361,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27279,7 +27387,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -27339,7 +27450,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27365,7 +27476,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -27429,7 +27540,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27455,7 +27566,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -27506,7 +27617,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27532,7 +27643,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -27583,7 +27697,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27609,7 +27723,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -27669,7 +27786,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27695,7 +27812,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -27763,7 +27880,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27789,7 +27906,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -27862,7 +27979,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27888,7 +28005,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -27942,7 +28059,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -27968,7 +28085,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -28019,7 +28136,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28045,7 +28162,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -28109,7 +28226,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28135,7 +28252,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -28196,7 +28313,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28222,7 +28339,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -28278,7 +28395,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28304,7 +28421,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -28369,7 +28489,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28395,7 +28515,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -28464,7 +28584,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28490,7 +28610,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -28549,7 +28669,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28575,7 +28695,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -28655,7 +28775,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28681,7 +28801,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -28759,7 +28879,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28785,7 +28905,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -28860,7 +28980,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28886,7 +29006,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -28966,7 +29086,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -28992,7 +29112,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29056,7 +29176,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29082,7 +29202,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29150,7 +29270,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29176,7 +29296,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29231,7 +29351,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29257,7 +29377,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29312,7 +29432,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29338,7 +29458,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29402,7 +29522,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29428,7 +29548,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29500,7 +29620,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29526,7 +29646,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29603,7 +29723,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29629,7 +29749,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29684,7 +29804,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29710,7 +29830,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29765,7 +29885,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29791,7 +29911,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29859,7 +29979,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29885,7 +30005,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -29950,7 +30070,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -29976,7 +30096,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -30036,7 +30156,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30062,7 +30182,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -30149,7 +30269,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30173,7 +30293,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -30230,7 +30350,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30254,7 +30374,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -30301,7 +30421,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30325,7 +30445,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -30393,7 +30516,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30417,7 +30540,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -30483,7 +30606,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30507,7 +30630,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -30570,7 +30693,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30594,7 +30717,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -30662,7 +30785,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30686,7 +30809,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -30738,7 +30864,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30762,7 +30888,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -30818,7 +30944,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30842,7 +30968,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -30885,7 +31011,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30909,7 +31035,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -30952,7 +31081,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -30976,7 +31105,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -31028,7 +31160,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31052,7 +31184,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -31112,7 +31244,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31136,7 +31268,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -31201,7 +31333,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31225,7 +31357,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -31271,7 +31403,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31295,7 +31427,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -31338,7 +31470,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31362,7 +31494,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -31418,7 +31550,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31442,7 +31574,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -31495,7 +31627,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31519,7 +31651,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -31567,7 +31699,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31591,7 +31723,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -31648,7 +31783,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31672,7 +31807,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -31733,7 +31868,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31757,7 +31892,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -31808,7 +31943,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31832,7 +31967,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -31904,7 +32039,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -31928,7 +32063,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -31998,7 +32133,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32022,7 +32157,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32089,7 +32224,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32113,7 +32248,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32185,7 +32320,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32209,7 +32344,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32265,7 +32400,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32289,7 +32424,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32349,7 +32484,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32373,7 +32508,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32420,7 +32555,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32444,7 +32579,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32491,7 +32626,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32515,7 +32650,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32571,7 +32706,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32595,7 +32730,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32659,7 +32794,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32683,7 +32818,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32752,7 +32887,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32776,7 +32911,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32823,7 +32958,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32847,7 +32982,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32894,7 +33029,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -32918,7 +33053,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -32978,7 +33113,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33002,7 +33137,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -33059,7 +33194,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33083,7 +33218,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -33135,7 +33270,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33159,7 +33294,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -33226,7 +33361,7 @@ type DeleteMethodTestRequestConfig = Readonly<
   >
 >
 
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33245,7 +33380,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
   extraInfo: {},
 }
 
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -33282,7 +33417,7 @@ type GetMethodTestRequestConfig = Readonly<
   >
 >
 
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33301,7 +33436,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
   extraInfo: {},
 }
 
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -33328,7 +33463,7 @@ type Json5ResponseTestRequestConfig = Readonly<
   >
 >
 
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33347,7 +33482,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
   extraInfo: {},
 }
 
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -33395,7 +33533,7 @@ type Json5RequestTestRequestConfig = Readonly<
   >
 >
 
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33414,7 +33552,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
   extraInfo: {},
 }
 
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -33460,7 +33598,7 @@ type PostMethodTestRequestConfig = Readonly<
   >
 >
 
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33479,7 +33617,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
   extraInfo: {},
 }
 
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -33522,7 +33660,7 @@ type PutMethodTestRequestConfig = Readonly<
   >
 >
 
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33541,7 +33679,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
   extraInfo: {},
 }
 
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -33589,7 +33727,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
   >
 >
 
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33608,7 +33746,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
   extraInfo: {},
 }
 
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -33640,7 +33781,7 @@ type UploadTestRequestConfig = Readonly<
   >
 >
 
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33659,7 +33800,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
   extraInfo: {},
 }
 
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -33695,7 +33836,7 @@ type TestTestRequestConfig = Readonly<
   >
 >
 
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33714,7 +33855,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
   extraInfo: {},
 }
 
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -33737,7 +33878,7 @@ type NoResponseDataTestRequestConfig = Readonly<
   >
 >
 
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33756,7 +33897,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
   extraInfo: {},
 }
 
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -33779,7 +33923,7 @@ type EmptyResponseTestRequestConfig = Readonly<
   >
 >
 
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33798,7 +33942,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
   extraInfo: {},
 }
 
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -33830,7 +33977,7 @@ type TestTestRequestConfig = Readonly<
   >
 >
 
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33849,7 +33996,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
   extraInfo: {},
 }
 
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -33889,7 +34036,7 @@ type HihihiTestRequestConfig = Readonly<
   >
 >
 
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33908,7 +34055,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
   extraInfo: {},
 }
 
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -33953,7 +34100,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
   >
 >
 
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -33972,7 +34119,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
   extraInfo: {},
 }
 
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -33998,7 +34145,7 @@ type RawResponseTestRequestConfig = Readonly<
   >
 >
 
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34017,7 +34164,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
   extraInfo: {},
 }
 
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -34040,7 +34187,7 @@ type HeadersTestRequestConfig = Readonly<
   >
 >
 
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34059,7 +34206,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
   extraInfo: {},
 }
 
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -34095,7 +34242,7 @@ type AvatarTestRequestConfig = Readonly<
   >
 >
 
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34114,7 +34261,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
   extraInfo: {},
 }
 
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -34147,7 +34294,7 @@ type DeepTestRequestConfig = Readonly<
   >
 >
 
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34166,7 +34313,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
   extraInfo: {},
 }
 
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -34194,7 +34341,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
   >
 >
 
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34213,7 +34360,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
   extraInfo: {},
 }
 
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -34252,7 +34402,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34272,7 +34422,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
 }
 
 
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34315,7 +34465,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34335,7 +34485,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
 }
 
 
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34368,7 +34518,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34388,7 +34538,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
 }
 
 
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34442,7 +34592,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34462,7 +34612,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
 }
 
 
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34514,7 +34664,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34534,7 +34684,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
 }
 
 
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34583,7 +34733,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34603,7 +34753,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
 }
 
 
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34657,7 +34807,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34677,7 +34827,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
 }
 
 
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34715,7 +34865,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34735,7 +34885,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
 }
 
 
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34777,7 +34927,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34797,7 +34947,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
 }
 
 
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34826,7 +34976,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34846,7 +34996,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
 }
 
 
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34875,7 +35025,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34895,7 +35045,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
 }
 
 
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34933,7 +35083,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -34953,7 +35103,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
 }
 
 
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -34999,7 +35149,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35019,7 +35169,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
 }
 
 
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -35070,7 +35220,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35090,7 +35240,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
 }
 
 
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -35119,7 +35269,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35139,7 +35289,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
 }
 
 
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -35168,7 +35318,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35188,7 +35338,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
 }
 
 
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -35230,7 +35380,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35250,7 +35400,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
 }
 
 
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -35289,7 +35439,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35309,7 +35459,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
 }
 
 
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -35343,7 +35493,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
 >>
 
 
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35363,7 +35513,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
 }
 
 
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -35454,7 +35604,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35479,7 +35629,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -35540,7 +35690,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35565,7 +35715,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -35616,7 +35766,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35641,7 +35791,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -35713,7 +35866,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35738,7 +35891,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -35808,7 +35961,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35833,7 +35986,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -35900,7 +36053,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -35925,7 +36078,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -35997,7 +36150,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36022,7 +36175,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -36078,7 +36234,7 @@ type UploadTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36103,7 +36259,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -36163,7 +36319,7 @@ type TestTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36188,7 +36344,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -36235,7 +36391,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36260,7 +36416,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -36307,7 +36466,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36332,7 +36491,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -36388,7 +36550,7 @@ type TestTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36413,7 +36575,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -36477,7 +36639,7 @@ type HihihiTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36502,7 +36664,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -36571,7 +36733,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36596,7 +36758,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -36646,7 +36808,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36671,7 +36833,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -36718,7 +36880,7 @@ type HeadersTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36743,7 +36905,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -36803,7 +36965,7 @@ type AvatarTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36828,7 +36990,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -36885,7 +37047,7 @@ type DeepTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36910,7 +37072,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -36962,7 +37124,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -36987,7 +37149,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -37048,7 +37213,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37073,7 +37238,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37138,7 +37303,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37163,7 +37328,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37218,7 +37383,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37243,7 +37408,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37319,7 +37484,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37344,7 +37509,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37418,7 +37583,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37443,7 +37608,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37514,7 +37679,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37539,7 +37704,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37615,7 +37780,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37640,7 +37805,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37700,7 +37865,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37725,7 +37890,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37789,7 +37954,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37814,7 +37979,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37865,7 +38030,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37890,7 +38055,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -37941,7 +38106,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -37966,7 +38131,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38026,7 +38191,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38051,7 +38216,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38119,7 +38284,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38144,7 +38309,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38217,7 +38382,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38242,7 +38407,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38293,7 +38458,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38318,7 +38483,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38369,7 +38534,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38394,7 +38559,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38458,7 +38623,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38483,7 +38648,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38544,7 +38709,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38569,7 +38734,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38625,7 +38790,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38650,7 +38815,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @分类 [test↗](http://foo.bar/project/11/interface/api/cat_18)
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -38745,7 +38910,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38771,7 +38936,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -38836,7 +39001,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38862,7 +39027,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -38917,7 +39082,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -38943,7 +39108,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -39019,7 +39187,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39045,7 +39213,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -39119,7 +39287,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39145,7 +39313,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -39216,7 +39384,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39242,7 +39410,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -39318,7 +39486,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39344,7 +39512,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -39404,7 +39575,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39430,7 +39601,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -39494,7 +39665,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39520,7 +39691,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -39571,7 +39742,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39597,7 +39768,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -39648,7 +39822,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39674,7 +39848,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -39734,7 +39911,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39760,7 +39937,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -39828,7 +40005,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39854,7 +40031,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -39927,7 +40104,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -39953,7 +40130,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -40007,7 +40184,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40033,7 +40210,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -40084,7 +40261,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40110,7 +40287,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -40174,7 +40351,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40200,7 +40377,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -40261,7 +40438,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40287,7 +40464,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -40343,7 +40520,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40369,7 +40546,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -40434,7 +40614,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40460,7 +40640,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -40529,7 +40709,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40555,7 +40735,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -40614,7 +40794,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40640,7 +40820,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -40720,7 +40900,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40746,7 +40926,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -40824,7 +41004,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40850,7 +41030,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -40925,7 +41105,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -40951,7 +41131,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41031,7 +41211,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41057,7 +41237,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41121,7 +41301,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41147,7 +41327,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41215,7 +41395,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41241,7 +41421,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41296,7 +41476,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41322,7 +41502,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41377,7 +41557,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41403,7 +41583,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41467,7 +41647,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41493,7 +41673,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41565,7 +41745,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41591,7 +41771,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41668,7 +41848,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41694,7 +41874,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41749,7 +41929,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41775,7 +41955,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41830,7 +42010,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41856,7 +42036,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -41924,7 +42104,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -41950,7 +42130,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -42015,7 +42195,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -42041,7 +42221,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -42101,7 +42281,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -42127,7 +42307,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -42222,7 +42402,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42248,7 +42428,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -42313,7 +42493,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42339,7 +42519,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -42394,7 +42574,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42420,7 +42600,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -42496,7 +42679,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42522,7 +42705,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -42596,7 +42779,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42622,7 +42805,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -42693,7 +42876,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42719,7 +42902,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -42795,7 +42978,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42821,7 +43004,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -42881,7 +43067,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42907,7 +43093,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -42971,7 +43157,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -42997,7 +43183,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -43048,7 +43234,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43074,7 +43260,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -43125,7 +43314,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43151,7 +43340,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -43211,7 +43403,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43237,7 +43429,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -43305,7 +43497,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43331,7 +43523,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -43404,7 +43596,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43430,7 +43622,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -43484,7 +43676,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43510,7 +43702,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -43561,7 +43753,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43587,7 +43779,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -43651,7 +43843,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43677,7 +43869,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -43738,7 +43930,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43764,7 +43956,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -43820,7 +44012,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -43846,7 +44038,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -43908,7 +44103,7 @@ type Get2TestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -43935,7 +44130,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (requestData?: Get2TestRequest, ...args: UserRequestRestArgs) => {
+export const get2Test = /*#__PURE__*/ (requestData?: Get2TestRequest, ...args: UserRequestRestArgs) => {
   return request<Get2TestResponse>(prepare(get2TestRequestConfig, requestData), ...args)
 }
 
@@ -43991,7 +44186,7 @@ type Picture_3dDetailTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
+const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -44017,7 +44212,10 @@ const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-export const picture_3dDetailTest = (requestData?: Picture_3dDetailTestRequest, ...args: UserRequestRestArgs) => {
+export const picture_3dDetailTest = /*#__PURE__*/ (
+  requestData?: Picture_3dDetailTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Picture_3dDetailTestResponse>(prepare(picture_3dDetailTestRequestConfig, requestData), ...args)
 }
 
@@ -44073,7 +44271,7 @@ type GetTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-const getTestRequestConfig: GetTestRequestConfig = {
+const getTestRequestConfig: GetTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -44099,7 +44297,7 @@ const getTestRequestConfig: GetTestRequestConfig = {
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-export const getTest = (requestData: GetTestRequest, ...args: UserRequestRestArgs) => {
+export const getTest = /*#__PURE__*/ (requestData: GetTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetTestResponse>(prepare(getTestRequestConfig, requestData), ...args)
 }
 
@@ -44156,7 +44354,7 @@ type FormTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-const formTestRequestConfig: FormTestRequestConfig = {
+const formTestRequestConfig: FormTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -44182,7 +44380,7 @@ const formTestRequestConfig: FormTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-export const formTest = (requestData: FormTestRequest, ...args: UserRequestRestArgs) => {
+export const formTest = /*#__PURE__*/ (requestData: FormTestRequest, ...args: UserRequestRestArgs) => {
   return request<FormTestResponse>(prepare(formTestRequestConfig, requestData), ...args)
 }
 
@@ -44248,7 +44446,7 @@ type JsonTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-const jsonTestRequestConfig: JsonTestRequestConfig = {
+const jsonTestRequestConfig: JsonTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -44274,7 +44472,7 @@ const jsonTestRequestConfig: JsonTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-export const jsonTest = (requestData: JsonTestRequest, ...args: UserRequestRestArgs) => {
+export const jsonTest = /*#__PURE__*/ (requestData: JsonTestRequest, ...args: UserRequestRestArgs) => {
   return request<JsonTestResponse>(prepare(jsonTestRequestConfig, requestData), ...args)
 }
 
@@ -44377,7 +44575,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -44403,7 +44601,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -44472,7 +44670,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -44498,7 +44696,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -44557,7 +44755,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -44583,7 +44781,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -44663,7 +44861,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -44689,7 +44887,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -44767,7 +44965,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -44793,7 +44991,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -44868,7 +45066,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -44894,7 +45092,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -44974,7 +45172,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45000,7 +45198,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45064,7 +45262,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45090,7 +45288,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45158,7 +45356,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45184,7 +45382,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45239,7 +45437,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45265,7 +45463,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45320,7 +45518,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45346,7 +45544,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45410,7 +45608,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45436,7 +45634,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45508,7 +45706,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45534,7 +45732,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45611,7 +45809,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45637,7 +45835,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45692,7 +45890,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45718,7 +45916,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45773,7 +45971,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45799,7 +45997,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45867,7 +46065,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45893,7 +46091,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -45958,7 +46156,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -45984,7 +46182,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -46044,7 +46242,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -46070,7 +46268,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -46135,7 +46333,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -46162,7 +46360,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -46221,7 +46419,7 @@ type Picture_3dDetailTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
+const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -46247,7 +46445,7 @@ const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-export const picture_3dDetailTest = (
+export const picture_3dDetailTest = /*#__PURE__*/ (
   requestData?: Picture_3dDetailTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -46307,7 +46505,7 @@ type GetTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-const getTestRequestConfig: GetTestRequestConfig = {
+const getTestRequestConfig: GetTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -46333,7 +46531,7 @@ const getTestRequestConfig: GetTestRequestConfig = {
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-export const getTest = (
+export const getTest = /*#__PURE__*/ (
   requestData: GetTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -46394,7 +46592,7 @@ type FormTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-const formTestRequestConfig: FormTestRequestConfig = {
+const formTestRequestConfig: FormTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -46420,7 +46618,7 @@ const formTestRequestConfig: FormTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-export const formTest = (
+export const formTest = /*#__PURE__*/ (
   requestData: FormTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -46490,7 +46688,7 @@ type JsonTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-const jsonTestRequestConfig: JsonTestRequestConfig = {
+const jsonTestRequestConfig: JsonTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -46516,7 +46714,7 @@ const jsonTestRequestConfig: JsonTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-export const jsonTest = (
+export const jsonTest = /*#__PURE__*/ (
   requestData: JsonTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -46611,7 +46809,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -46637,7 +46835,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -46702,7 +46900,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -46728,7 +46926,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -46783,7 +46981,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -46809,7 +47007,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -46885,7 +47086,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -46911,7 +47112,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -46985,7 +47186,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47011,7 +47212,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -47082,7 +47283,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47108,7 +47309,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -47184,7 +47385,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47210,7 +47411,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -47270,7 +47474,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47296,7 +47500,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -47360,7 +47564,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47386,7 +47590,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -47437,7 +47641,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47463,7 +47667,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -47514,7 +47721,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47540,7 +47747,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -47600,7 +47810,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47626,7 +47836,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -47694,7 +47904,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47720,7 +47930,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -47793,7 +48003,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47819,7 +48029,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -47873,7 +48083,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47899,7 +48109,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -47950,7 +48160,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -47976,7 +48186,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -48040,7 +48250,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48066,7 +48276,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -48127,7 +48337,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48153,7 +48363,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -48209,7 +48419,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48235,7 +48445,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -48338,7 +48551,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48364,7 +48577,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -48433,7 +48646,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48459,7 +48672,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -48518,7 +48731,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48544,7 +48757,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -48624,7 +48837,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48650,7 +48863,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -48728,7 +48941,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48754,7 +48967,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -48829,7 +49042,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48855,7 +49068,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -48935,7 +49148,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -48961,7 +49174,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49025,7 +49238,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49051,7 +49264,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49119,7 +49332,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49145,7 +49358,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49200,7 +49413,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49226,7 +49439,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49281,7 +49494,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49307,7 +49520,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49371,7 +49584,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49397,7 +49610,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49469,7 +49682,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49495,7 +49708,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49572,7 +49785,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49598,7 +49811,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49653,7 +49866,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49679,7 +49892,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49734,7 +49947,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49760,7 +49973,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49828,7 +50041,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49854,7 +50067,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -49919,7 +50132,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -49945,7 +50158,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -50005,7 +50218,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50031,7 +50244,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -50126,7 +50339,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50152,7 +50365,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -50217,7 +50430,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50243,7 +50456,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -50298,7 +50511,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50324,7 +50537,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -50400,7 +50616,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50426,7 +50642,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -50500,7 +50716,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50526,7 +50742,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -50597,7 +50813,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50623,7 +50839,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -50699,7 +50915,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50725,7 +50941,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -50785,7 +51004,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50811,7 +51030,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -50875,7 +51094,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50901,7 +51120,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -50952,7 +51171,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -50978,7 +51197,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -51029,7 +51251,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51055,7 +51277,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -51115,7 +51340,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51141,7 +51366,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -51209,7 +51434,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51235,7 +51460,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -51308,7 +51533,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51334,7 +51559,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -51388,7 +51613,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51414,7 +51639,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -51465,7 +51690,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51491,7 +51716,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -51555,7 +51780,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51581,7 +51806,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -51642,7 +51867,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51668,7 +51893,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -51724,7 +51949,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51750,7 +51975,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -51812,7 +52040,7 @@ type Get2TestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -51839,7 +52067,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (requestData?: Get2TestRequest, ...args: UserRequestRestArgs) => {
+export const get2Test = /*#__PURE__*/ (requestData?: Get2TestRequest, ...args: UserRequestRestArgs) => {
   return request<Get2TestResponse>(prepare(get2TestRequestConfig, requestData), ...args)
 }
 
@@ -51942,7 +52170,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -51968,7 +52196,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52037,7 +52265,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52063,7 +52291,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52122,7 +52350,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52148,7 +52376,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52228,7 +52456,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52254,7 +52482,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52332,7 +52560,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52358,7 +52586,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52433,7 +52661,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52459,7 +52687,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52539,7 +52767,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52565,7 +52793,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52629,7 +52857,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52655,7 +52883,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52723,7 +52951,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52749,7 +52977,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52804,7 +53032,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52830,7 +53058,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52885,7 +53113,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -52911,7 +53139,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -52975,7 +53203,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53001,7 +53229,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53073,7 +53301,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53099,7 +53327,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53176,7 +53404,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53202,7 +53430,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53257,7 +53485,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53283,7 +53511,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53338,7 +53566,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53364,7 +53592,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53432,7 +53660,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53458,7 +53686,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53523,7 +53751,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53549,7 +53777,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53609,7 +53837,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -53635,7 +53863,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53700,7 +53928,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -53727,7 +53955,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -53823,7 +54051,7 @@ type Get2TestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -53850,7 +54078,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (requestData?: Get2TestRequest, ...args: UserRequestRestArgs) => {
+export const get2Test = /*#__PURE__*/ (requestData?: Get2TestRequest, ...args: UserRequestRestArgs) => {
   return request<Get2TestResponse>(prepare(get2TestRequestConfig, requestData), ...args)
 }
 
@@ -53906,7 +54134,7 @@ type Picture_3dDetailTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
+const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -53932,7 +54160,10 @@ const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-export const picture_3dDetailTest = (requestData?: Picture_3dDetailTestRequest, ...args: UserRequestRestArgs) => {
+export const picture_3dDetailTest = /*#__PURE__*/ (
+  requestData?: Picture_3dDetailTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Picture_3dDetailTestResponse>(prepare(picture_3dDetailTestRequestConfig, requestData), ...args)
 }
 
@@ -53988,7 +54219,7 @@ type GetTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-const getTestRequestConfig: GetTestRequestConfig = {
+const getTestRequestConfig: GetTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -54014,7 +54245,7 @@ const getTestRequestConfig: GetTestRequestConfig = {
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-export const getTest = (requestData: GetTestRequest, ...args: UserRequestRestArgs) => {
+export const getTest = /*#__PURE__*/ (requestData: GetTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetTestResponse>(prepare(getTestRequestConfig, requestData), ...args)
 }
 
@@ -54071,7 +54302,7 @@ type FormTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-const formTestRequestConfig: FormTestRequestConfig = {
+const formTestRequestConfig: FormTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -54097,7 +54328,7 @@ const formTestRequestConfig: FormTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-export const formTest = (requestData: FormTestRequest, ...args: UserRequestRestArgs) => {
+export const formTest = /*#__PURE__*/ (requestData: FormTestRequest, ...args: UserRequestRestArgs) => {
   return request<FormTestResponse>(prepare(formTestRequestConfig, requestData), ...args)
 }
 
@@ -54163,7 +54394,7 @@ type JsonTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-const jsonTestRequestConfig: JsonTestRequestConfig = {
+const jsonTestRequestConfig: JsonTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -54189,7 +54420,7 @@ const jsonTestRequestConfig: JsonTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-export const jsonTest = (requestData: JsonTestRequest, ...args: UserRequestRestArgs) => {
+export const jsonTest = /*#__PURE__*/ (requestData: JsonTestRequest, ...args: UserRequestRestArgs) => {
   return request<JsonTestResponse>(prepare(jsonTestRequestConfig, requestData), ...args)
 }
 
@@ -54293,7 +54524,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -54320,7 +54551,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -54379,7 +54610,7 @@ type Picture_3dDetailTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
+const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -54405,7 +54636,7 @@ const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-export const picture_3dDetailTest = (
+export const picture_3dDetailTest = /*#__PURE__*/ (
   requestData?: Picture_3dDetailTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -54465,7 +54696,7 @@ type GetTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-const getTestRequestConfig: GetTestRequestConfig = {
+const getTestRequestConfig: GetTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -54491,7 +54722,7 @@ const getTestRequestConfig: GetTestRequestConfig = {
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-export const getTest = (
+export const getTest = /*#__PURE__*/ (
   requestData: GetTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -54552,7 +54783,7 @@ type FormTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-const formTestRequestConfig: FormTestRequestConfig = {
+const formTestRequestConfig: FormTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -54578,7 +54809,7 @@ const formTestRequestConfig: FormTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-export const formTest = (
+export const formTest = /*#__PURE__*/ (
   requestData: FormTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -54648,7 +54879,7 @@ type JsonTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-const jsonTestRequestConfig: JsonTestRequestConfig = {
+const jsonTestRequestConfig: JsonTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -54674,7 +54905,7 @@ const jsonTestRequestConfig: JsonTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-export const jsonTest = (
+export const jsonTest = /*#__PURE__*/ (
   requestData: JsonTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -54734,7 +54965,7 @@ const deleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData, ...args) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(deleteMethodTestRequestConfig, requestData), ...args);
 };
 deleteMethodTest.requestConfig = deleteMethodTestRequestConfig;
@@ -54770,7 +55001,7 @@ const getMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData, ...args) => {
+export const getMethodTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(getMethodTestRequestConfig, requestData), ...args);
 };
 getMethodTest.requestConfig = getMethodTestRequestConfig;
@@ -54806,7 +55037,7 @@ const json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData, ...args) => {
+export const json5ResponseTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(json5ResponseTestRequestConfig, requestData), ...args);
 };
 json5ResponseTest.requestConfig = json5ResponseTestRequestConfig;
@@ -54842,7 +55073,7 @@ const json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData, ...args) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(json5RequestTestRequestConfig, requestData), ...args);
 };
 json5RequestTest.requestConfig = json5RequestTestRequestConfig;
@@ -54878,7 +55109,7 @@ const postMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData, ...args) => {
+export const postMethodTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(postMethodTestRequestConfig, requestData), ...args);
 };
 postMethodTest.requestConfig = postMethodTestRequestConfig;
@@ -54914,7 +55145,7 @@ const putMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData, ...args) => {
+export const putMethodTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(putMethodTestRequestConfig, requestData), ...args);
 };
 putMethodTest.requestConfig = putMethodTestRequestConfig;
@@ -54950,7 +55181,7 @@ const dataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData, ...args) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(dataKeyExampleTestRequestConfig, requestData), ...args);
 };
 dataKeyExampleTest.requestConfig = dataKeyExampleTestRequestConfig;
@@ -54986,7 +55217,7 @@ const uploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData, ...args) => {
+export const uploadTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(uploadTestRequestConfig, requestData), ...args);
 };
 uploadTest.requestConfig = uploadTestRequestConfig;
@@ -55022,7 +55253,7 @@ const testTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData, ...args) => {
+export const testTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(testTestRequestConfig, requestData), ...args);
 };
 testTest.requestConfig = testTestRequestConfig;
@@ -55058,7 +55289,7 @@ const noResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData, ...args) => {
+export const noResponseDataTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(noResponseDataTestRequestConfig, requestData), ...args);
 };
 noResponseDataTest.requestConfig = noResponseDataTestRequestConfig;
@@ -55094,7 +55325,7 @@ const emptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData, ...args) => {
+export const emptyResponseTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(emptyResponseTestRequestConfig, requestData), ...args);
 };
 emptyResponseTest.requestConfig = emptyResponseTestRequestConfig;
@@ -55130,7 +55361,7 @@ const testTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData, ...args) => {
+export const testTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(testTestRequestConfig, requestData), ...args);
 };
 testTest.requestConfig = testTestRequestConfig;
@@ -55166,7 +55397,7 @@ const hihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData, ...args) => {
+export const hihihiTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(hihihiTestRequestConfig, requestData), ...args);
 };
 hihihiTest.requestConfig = hihihiTestRequestConfig;
@@ -55202,7 +55433,7 @@ const hihihi_1608478638207TestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (requestData, ...args) => {
+export const hihihi_1608478638207Test = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(hihihi_1608478638207TestRequestConfig, requestData), ...args);
 };
 hihihi_1608478638207Test.requestConfig = hihihi_1608478638207TestRequestConfig;
@@ -55238,7 +55469,7 @@ const rawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData, ...args) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(rawResponseTestRequestConfig, requestData), ...args);
 };
 rawResponseTest.requestConfig = rawResponseTestRequestConfig;
@@ -55274,7 +55505,7 @@ const headersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData, ...args) => {
+export const headersTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(headersTestRequestConfig, requestData), ...args);
 };
 headersTest.requestConfig = headersTestRequestConfig;
@@ -55310,7 +55541,7 @@ const avatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData, ...args) => {
+export const avatarTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(avatarTestRequestConfig, requestData), ...args);
 };
 avatarTest.requestConfig = avatarTestRequestConfig;
@@ -55346,7 +55577,7 @@ const deepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData, ...args) => {
+export const deepTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(deepTestRequestConfig, requestData), ...args);
 };
 deepTest.requestConfig = deepTestRequestConfig;
@@ -55382,7 +55613,7 @@ const onlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData, ...args) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args);
 };
 onlyPostFormDataTest.requestConfig = onlyPostFormDataTestRequestConfig;
@@ -55424,7 +55655,7 @@ const get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (requestData, ...args) => {
+export const get2Test = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(get2TestRequestConfig, requestData), ...args);
 };
 get2Test.requestConfig = get2TestRequestConfig;
@@ -55464,7 +55695,7 @@ const picture_3dDetailTestRequestConfig = {
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-export const picture_3dDetailTest = (requestData, ...args) => {
+export const picture_3dDetailTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(picture_3dDetailTestRequestConfig, requestData), ...args);
 };
 picture_3dDetailTest.requestConfig = picture_3dDetailTestRequestConfig;
@@ -55500,7 +55731,7 @@ const getTestRequestConfig = {
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-export const getTest = (requestData, ...args) => {
+export const getTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(getTestRequestConfig, requestData), ...args);
 };
 getTest.requestConfig = getTestRequestConfig;
@@ -55536,7 +55767,7 @@ const formTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-export const formTest = (requestData, ...args) => {
+export const formTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(formTestRequestConfig, requestData), ...args);
 };
 formTest.requestConfig = formTestRequestConfig;
@@ -55572,7 +55803,7 @@ const jsonTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-export const jsonTest = (requestData, ...args) => {
+export const jsonTest = /*#__PURE__*/ (requestData, ...args) => {
     return request(prepare(jsonTestRequestConfig, requestData), ...args);
 };
 jsonTest.requestConfig = jsonTestRequestConfig;
@@ -55654,7 +55885,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -55680,7 +55911,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -55749,7 +55980,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -55775,7 +56006,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -55834,7 +56065,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -55860,7 +56091,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -55940,7 +56171,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -55966,7 +56197,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56044,7 +56275,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56070,7 +56301,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56145,7 +56376,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56171,7 +56402,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56251,7 +56482,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56277,7 +56508,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56341,7 +56572,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56367,7 +56598,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56435,7 +56666,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56461,7 +56692,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56516,7 +56747,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56542,7 +56773,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56597,7 +56828,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56623,7 +56854,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56687,7 +56918,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56713,7 +56944,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56785,7 +57016,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56811,7 +57042,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56888,7 +57119,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56914,7 +57145,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -56969,7 +57200,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -56995,7 +57226,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57050,7 +57281,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -57076,7 +57307,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57144,7 +57375,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -57170,7 +57401,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57235,7 +57466,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -57261,7 +57492,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57321,7 +57552,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -57347,7 +57578,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57412,7 +57643,7 @@ type Get2TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-const get2TestRequestConfig: Get2TestRequestConfig = {
+const get2TestRequestConfig: Get2TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -57439,7 +57670,7 @@ const get2TestRequestConfig: Get2TestRequestConfig = {
  * @请求头 \`GET /__hello__/get2_test\`
  * @更新时间 1610557430
  */
-export const get2Test = (
+export const get2Test = /*#__PURE__*/ (
   requestData?: Get2TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57498,7 +57729,7 @@ type Picture_3dDetailTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
+const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -57524,7 +57755,7 @@ const picture_3dDetailTestRequestConfig: Picture_3dDetailTestRequestConfig = {
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail_test\`
  * @更新时间 1610557430
  */
-export const picture_3dDetailTest = (
+export const picture_3dDetailTest = /*#__PURE__*/ (
   requestData?: Picture_3dDetailTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57584,7 +57815,7 @@ type GetTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-const getTestRequestConfig: GetTestRequestConfig = {
+const getTestRequestConfig: GetTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -57610,7 +57841,7 @@ const getTestRequestConfig: GetTestRequestConfig = {
  * @请求头 \`GET /__hello__/28/get_test\`
  * @更新时间 1610557430
  */
-export const getTest = (
+export const getTest = /*#__PURE__*/ (
   requestData: GetTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57671,7 +57902,7 @@ type FormTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-const formTestRequestConfig: FormTestRequestConfig = {
+const formTestRequestConfig: FormTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -57697,7 +57928,7 @@ const formTestRequestConfig: FormTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form_test\`
  * @更新时间 1610557431
  */
-export const formTest = (
+export const formTest = /*#__PURE__*/ (
   requestData: FormTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57767,7 +57998,7 @@ type JsonTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-const jsonTestRequestConfig: JsonTestRequestConfig = {
+const jsonTestRequestConfig: JsonTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -57793,7 +58024,7 @@ const jsonTestRequestConfig: JsonTestRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json_test\`
  * @更新时间 1610557431
  */
-export const jsonTest = (
+export const jsonTest = /*#__PURE__*/ (
   requestData: JsonTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -57921,7 +58152,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -57947,7 +58178,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -57960,7 +58191,7 @@ deleteMethodTest.requestConfig = deleteMethodTestRequestConfig
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const useDeleteMethodTest = makeRequestHook<
+export const useDeleteMethodTest = /*#__PURE__*/ makeRequestHook<
   DeleteMethodTestRequest,
   DeleteMethodTestRequestConfig,
   ReturnType<typeof deleteMethodTest>
@@ -58025,7 +58256,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58051,7 +58282,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -58064,7 +58295,7 @@ getMethodTest.requestConfig = getMethodTestRequestConfig
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const useGetMethodTest = makeRequestHook<
+export const useGetMethodTest = /*#__PURE__*/ makeRequestHook<
   GetMethodTestRequest,
   GetMethodTestRequestConfig,
   ReturnType<typeof getMethodTest>
@@ -58119,7 +58350,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58145,7 +58376,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -58158,7 +58392,7 @@ json5ResponseTest.requestConfig = json5ResponseTestRequestConfig
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const useJson5ResponseTest = makeRequestHook<
+export const useJson5ResponseTest = /*#__PURE__*/ makeRequestHook<
   Json5ResponseTestRequest,
   Json5ResponseTestRequestConfig,
   ReturnType<typeof json5ResponseTest>
@@ -58234,7 +58468,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58260,7 +58494,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -58273,7 +58507,7 @@ json5RequestTest.requestConfig = json5RequestTestRequestConfig
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const useJson5RequestTest = makeRequestHook<
+export const useJson5RequestTest = /*#__PURE__*/ makeRequestHook<
   Json5RequestTestRequest,
   Json5RequestTestRequestConfig,
   ReturnType<typeof json5RequestTest>
@@ -58347,7 +58581,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58373,7 +58607,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -58386,7 +58620,7 @@ postMethodTest.requestConfig = postMethodTestRequestConfig
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const usePostMethodTest = makeRequestHook<
+export const usePostMethodTest = /*#__PURE__*/ makeRequestHook<
   PostMethodTestRequest,
   PostMethodTestRequestConfig,
   ReturnType<typeof postMethodTest>
@@ -58457,7 +58691,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58483,7 +58717,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -58496,7 +58730,7 @@ putMethodTest.requestConfig = putMethodTestRequestConfig
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const usePutMethodTest = makeRequestHook<
+export const usePutMethodTest = /*#__PURE__*/ makeRequestHook<
   PutMethodTestRequest,
   PutMethodTestRequestConfig,
   ReturnType<typeof putMethodTest>
@@ -58572,7 +58806,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58598,7 +58832,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -58611,7 +58848,7 @@ dataKeyExampleTest.requestConfig = dataKeyExampleTestRequestConfig
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const useDataKeyExampleTest = makeRequestHook<
+export const useDataKeyExampleTest = /*#__PURE__*/ makeRequestHook<
   DataKeyExampleTestRequest,
   DataKeyExampleTestRequestConfig,
   ReturnType<typeof dataKeyExampleTest>
@@ -58671,7 +58908,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58697,7 +58934,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -58710,9 +58947,11 @@ uploadTest.requestConfig = uploadTestRequestConfig
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const useUploadTest = makeRequestHook<UploadTestRequest, UploadTestRequestConfig, ReturnType<typeof uploadTest>>(
-  uploadTest,
-)
+export const useUploadTest = /*#__PURE__*/ makeRequestHook<
+  UploadTestRequest,
+  UploadTestRequestConfig,
+  ReturnType<typeof uploadTest>
+>(uploadTest)
 
 /**
  * 接口 [查询参数+对象↗](http://foo.bar/project/11/interface/api/93) 的 **请求类型**
@@ -58772,7 +59011,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58798,7 +59037,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -58811,9 +59050,11 @@ testTest.requestConfig = testTestRequestConfig
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const useTestTest = makeRequestHook<TestTestRequest, TestTestRequestConfig, ReturnType<typeof testTest>>(
-  testTest,
-)
+export const useTestTest = /*#__PURE__*/ makeRequestHook<
+  TestTestRequest,
+  TestTestRequestConfig,
+  ReturnType<typeof testTest>
+>(testTest)
 
 /**
  * 接口 [没返回数据↗](http://foo.bar/project/11/interface/api/99) 的 **请求类型**
@@ -58860,7 +59101,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58886,7 +59127,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -58899,7 +59143,7 @@ noResponseDataTest.requestConfig = noResponseDataTestRequestConfig
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const useNoResponseDataTest = makeRequestHook<
+export const useNoResponseDataTest = /*#__PURE__*/ makeRequestHook<
   NoResponseDataTestRequest,
   NoResponseDataTestRequestConfig,
   ReturnType<typeof noResponseDataTest>
@@ -58950,7 +59194,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -58976,7 +59220,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -58989,7 +59236,7 @@ emptyResponseTest.requestConfig = emptyResponseTestRequestConfig
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const useEmptyResponseTest = makeRequestHook<
+export const useEmptyResponseTest = /*#__PURE__*/ makeRequestHook<
   EmptyResponseTestRequest,
   EmptyResponseTestRequestConfig,
   ReturnType<typeof emptyResponseTest>
@@ -59049,7 +59296,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59075,7 +59322,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -59088,9 +59335,11 @@ testTest.requestConfig = testTestRequestConfig
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const useTestTest = makeRequestHook<TestTestRequest, TestTestRequestConfig, ReturnType<typeof testTest>>(
-  testTest,
-)
+export const useTestTest = /*#__PURE__*/ makeRequestHook<
+  TestTestRequest,
+  TestTestRequestConfig,
+  ReturnType<typeof testTest>
+>(testTest)
 
 /**
  * 接口 [路径参数+对象↗](http://foo.bar/project/11/interface/api/117) 的 **请求类型**
@@ -59154,7 +59403,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59180,7 +59429,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -59193,9 +59442,11 @@ hihihiTest.requestConfig = hihihiTestRequestConfig
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const useHihihiTest = makeRequestHook<HihihiTestRequest, HihihiTestRequestConfig, ReturnType<typeof hihihiTest>>(
-  hihihiTest,
-)
+export const useHihihiTest = /*#__PURE__*/ makeRequestHook<
+  HihihiTestRequest,
+  HihihiTestRequestConfig,
+  ReturnType<typeof hihihiTest>
+>(hihihiTest)
 
 /**
  * 接口 [路径参数+查询参数+对象↗](http://foo.bar/project/11/interface/api/123) 的 **请求类型**
@@ -59264,7 +59515,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59290,7 +59541,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -59306,7 +59557,7 @@ hihihi_1608478638207Test.requestConfig = hihihi_1608478638207TestRequestConfig
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const useHihihi_1608478638207Test = makeRequestHook<
+export const useHihihi_1608478638207Test = /*#__PURE__*/ makeRequestHook<
   Hihihi_1608478638207TestRequest,
   Hihihi_1608478638207TestRequestConfig,
   ReturnType<typeof hihihi_1608478638207Test>
@@ -59357,7 +59608,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59383,7 +59634,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -59396,7 +59647,7 @@ rawResponseTest.requestConfig = rawResponseTestRequestConfig
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const useRawResponseTest = makeRequestHook<
+export const useRawResponseTest = /*#__PURE__*/ makeRequestHook<
   RawResponseTestRequest,
   RawResponseTestRequestConfig,
   ReturnType<typeof rawResponseTest>
@@ -59447,7 +59698,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59473,7 +59724,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -59486,7 +59737,7 @@ headersTest.requestConfig = headersTestRequestConfig
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const useHeadersTest = makeRequestHook<
+export const useHeadersTest = /*#__PURE__*/ makeRequestHook<
   HeadersTestRequest,
   HeadersTestRequestConfig,
   ReturnType<typeof headersTest>
@@ -59550,7 +59801,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59576,7 +59827,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -59589,9 +59840,11 @@ avatarTest.requestConfig = avatarTestRequestConfig
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const useAvatarTest = makeRequestHook<AvatarTestRequest, AvatarTestRequestConfig, ReturnType<typeof avatarTest>>(
-  avatarTest,
-)
+export const useAvatarTest = /*#__PURE__*/ makeRequestHook<
+  AvatarTestRequest,
+  AvatarTestRequestConfig,
+  ReturnType<typeof avatarTest>
+>(avatarTest)
 
 /**
  * 接口 [dataKey 深度路径↗](http://foo.bar/project/11/interface/api/1167) 的 **请求类型**
@@ -59648,7 +59901,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59674,7 +59927,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -59687,9 +59940,11 @@ deepTest.requestConfig = deepTestRequestConfig
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const useDeepTest = makeRequestHook<DeepTestRequest, DeepTestRequestConfig, ReturnType<typeof deepTest>>(
-  deepTest,
-)
+export const useDeepTest = /*#__PURE__*/ makeRequestHook<
+  DeepTestRequest,
+  DeepTestRequestConfig,
+  ReturnType<typeof deepTest>
+>(deepTest)
 
 /**
  * 接口 [fix: 仅 POST 类接口处理表单数据↗](http://foo.bar/project/11/interface/api/1345) 的 **请求类型**
@@ -59741,7 +59996,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59767,7 +60022,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -59780,7 +60038,7 @@ onlyPostFormDataTest.requestConfig = onlyPostFormDataTestRequestConfig
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const useOnlyPostFormDataTest = makeRequestHook<
+export const useOnlyPostFormDataTest = /*#__PURE__*/ makeRequestHook<
   OnlyPostFormDataTestRequest,
   OnlyPostFormDataTestRequestConfig,
   ReturnType<typeof onlyPostFormDataTest>
@@ -59883,7 +60141,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -59909,7 +60167,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -59928,7 +60186,7 @@ deleteMethodTest.requestConfig = deleteMethodTestRequestConfig
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const useDeleteMethodTest = makeRequestHook<DeleteMethodTestRequest, DeleteMethodTestRequestConfig, ReturnType<typeof deleteMethodTest>>(deleteMethodTest)
+export const useDeleteMethodTest = /*#__PURE__*/ makeRequestHook<DeleteMethodTestRequest, DeleteMethodTestRequestConfig, ReturnType<typeof deleteMethodTest>>(deleteMethodTest)
 
 /**
  * 接口 [GET 方法↗](http://foo.bar/project/11/interface/api/51) 的 **请求类型**
@@ -59987,7 +60245,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60013,7 +60271,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60032,7 +60290,7 @@ getMethodTest.requestConfig = getMethodTestRequestConfig
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const useGetMethodTest = makeRequestHook<GetMethodTestRequest, GetMethodTestRequestConfig, ReturnType<typeof getMethodTest>>(getMethodTest)
+export const useGetMethodTest = /*#__PURE__*/ makeRequestHook<GetMethodTestRequest, GetMethodTestRequestConfig, ReturnType<typeof getMethodTest>>(getMethodTest)
 
 /**
  * 接口 [JSON5 响应↗](http://foo.bar/project/11/interface/api/57) 的 **请求类型**
@@ -60081,7 +60339,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60107,7 +60365,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60126,7 +60384,7 @@ json5ResponseTest.requestConfig = json5ResponseTestRequestConfig
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const useJson5ResponseTest = makeRequestHook<Json5ResponseTestRequest, Json5ResponseTestRequestConfig, ReturnType<typeof json5ResponseTest>>(json5ResponseTest)
+export const useJson5ResponseTest = /*#__PURE__*/ makeRequestHook<Json5ResponseTestRequest, Json5ResponseTestRequestConfig, ReturnType<typeof json5ResponseTest>>(json5ResponseTest)
 
 /**
  * 接口 [JSON5 请求↗](http://foo.bar/project/11/interface/api/63) 的 **请求类型**
@@ -60196,7 +60454,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60222,7 +60480,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60241,7 +60499,7 @@ json5RequestTest.requestConfig = json5RequestTestRequestConfig
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const useJson5RequestTest = makeRequestHook<Json5RequestTestRequest, Json5RequestTestRequestConfig, ReturnType<typeof json5RequestTest>>(json5RequestTest)
+export const useJson5RequestTest = /*#__PURE__*/ makeRequestHook<Json5RequestTestRequest, Json5RequestTestRequestConfig, ReturnType<typeof json5RequestTest>>(json5RequestTest)
 
 /**
  * 接口 [POST 方法↗](http://foo.bar/project/11/interface/api/69) 的 **请求类型**
@@ -60309,7 +60567,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60335,7 +60593,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60354,7 +60612,7 @@ postMethodTest.requestConfig = postMethodTestRequestConfig
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const usePostMethodTest = makeRequestHook<PostMethodTestRequest, PostMethodTestRequestConfig, ReturnType<typeof postMethodTest>>(postMethodTest)
+export const usePostMethodTest = /*#__PURE__*/ makeRequestHook<PostMethodTestRequest, PostMethodTestRequestConfig, ReturnType<typeof postMethodTest>>(postMethodTest)
 
 /**
  * 接口 [PUT 方法↗](http://foo.bar/project/11/interface/api/75) 的 **请求类型**
@@ -60419,7 +60677,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60445,7 +60703,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60464,7 +60722,7 @@ putMethodTest.requestConfig = putMethodTestRequestConfig
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const usePutMethodTest = makeRequestHook<PutMethodTestRequest, PutMethodTestRequestConfig, ReturnType<typeof putMethodTest>>(putMethodTest)
+export const usePutMethodTest = /*#__PURE__*/ makeRequestHook<PutMethodTestRequest, PutMethodTestRequestConfig, ReturnType<typeof putMethodTest>>(putMethodTest)
 
 /**
  * 接口 [dataKey 例子↗](http://foo.bar/project/11/interface/api/81) 的 **请求类型**
@@ -60534,7 +60792,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60560,7 +60818,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60579,7 +60837,7 @@ dataKeyExampleTest.requestConfig = dataKeyExampleTestRequestConfig
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const useDataKeyExampleTest = makeRequestHook<DataKeyExampleTestRequest, DataKeyExampleTestRequestConfig, ReturnType<typeof dataKeyExampleTest>>(dataKeyExampleTest)
+export const useDataKeyExampleTest = /*#__PURE__*/ makeRequestHook<DataKeyExampleTestRequest, DataKeyExampleTestRequestConfig, ReturnType<typeof dataKeyExampleTest>>(dataKeyExampleTest)
 
 /**
  * 接口 [文件↗](http://foo.bar/project/11/interface/api/87) 的 **请求类型**
@@ -60633,7 +60891,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60659,7 +60917,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60678,7 +60936,7 @@ uploadTest.requestConfig = uploadTestRequestConfig
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const useUploadTest = makeRequestHook<UploadTestRequest, UploadTestRequestConfig, ReturnType<typeof uploadTest>>(uploadTest)
+export const useUploadTest = /*#__PURE__*/ makeRequestHook<UploadTestRequest, UploadTestRequestConfig, ReturnType<typeof uploadTest>>(uploadTest)
 
 /**
  * 接口 [查询参数+对象↗](http://foo.bar/project/11/interface/api/93) 的 **请求类型**
@@ -60736,7 +60994,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60762,7 +61020,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60781,7 +61039,7 @@ testTest.requestConfig = testTestRequestConfig
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const useTestTest = makeRequestHook<TestTestRequest, TestTestRequestConfig, ReturnType<typeof testTest>>(testTest)
+export const useTestTest = /*#__PURE__*/ makeRequestHook<TestTestRequest, TestTestRequestConfig, ReturnType<typeof testTest>>(testTest)
 
 /**
  * 接口 [没返回数据↗](http://foo.bar/project/11/interface/api/99) 的 **请求类型**
@@ -60826,7 +61084,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60852,7 +61110,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60871,7 +61129,7 @@ noResponseDataTest.requestConfig = noResponseDataTestRequestConfig
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const useNoResponseDataTest = makeRequestHook<NoResponseDataTestRequest, NoResponseDataTestRequestConfig, ReturnType<typeof noResponseDataTest>>(noResponseDataTest)
+export const useNoResponseDataTest = /*#__PURE__*/ makeRequestHook<NoResponseDataTestRequest, NoResponseDataTestRequestConfig, ReturnType<typeof noResponseDataTest>>(noResponseDataTest)
 
 /**
  * 接口 [空返回数据↗](http://foo.bar/project/11/interface/api/105) 的 **请求类型**
@@ -60916,7 +61174,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -60942,7 +61200,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -60961,7 +61219,7 @@ emptyResponseTest.requestConfig = emptyResponseTestRequestConfig
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const useEmptyResponseTest = makeRequestHook<EmptyResponseTestRequest, EmptyResponseTestRequestConfig, ReturnType<typeof emptyResponseTest>>(emptyResponseTest)
+export const useEmptyResponseTest = /*#__PURE__*/ makeRequestHook<EmptyResponseTestRequest, EmptyResponseTestRequestConfig, ReturnType<typeof emptyResponseTest>>(emptyResponseTest)
 
 /**
  * 接口 [路径参数↗](http://foo.bar/project/11/interface/api/111) 的 **请求类型**
@@ -61015,7 +61273,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61041,7 +61299,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61060,7 +61318,7 @@ testTest.requestConfig = testTestRequestConfig
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const useTestTest = makeRequestHook<TestTestRequest, TestTestRequestConfig, ReturnType<typeof testTest>>(testTest)
+export const useTestTest = /*#__PURE__*/ makeRequestHook<TestTestRequest, TestTestRequestConfig, ReturnType<typeof testTest>>(testTest)
 
 /**
  * 接口 [路径参数+对象↗](http://foo.bar/project/11/interface/api/117) 的 **请求类型**
@@ -61122,7 +61380,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61148,7 +61406,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61167,7 +61425,7 @@ hihihiTest.requestConfig = hihihiTestRequestConfig
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const useHihihiTest = makeRequestHook<HihihiTestRequest, HihihiTestRequestConfig, ReturnType<typeof hihihiTest>>(hihihiTest)
+export const useHihihiTest = /*#__PURE__*/ makeRequestHook<HihihiTestRequest, HihihiTestRequestConfig, ReturnType<typeof hihihiTest>>(hihihiTest)
 
 /**
  * 接口 [路径参数+查询参数+对象↗](http://foo.bar/project/11/interface/api/123) 的 **请求类型**
@@ -61234,7 +61492,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61260,7 +61518,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61279,7 +61537,7 @@ hihihi_1608478638207Test.requestConfig = hihihi_1608478638207TestRequestConfig
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const useHihihi_1608478638207Test = makeRequestHook<Hihihi_1608478638207TestRequest, Hihihi_1608478638207TestRequestConfig, ReturnType<typeof hihihi_1608478638207Test>>(hihihi_1608478638207Test)
+export const useHihihi_1608478638207Test = /*#__PURE__*/ makeRequestHook<Hihihi_1608478638207TestRequest, Hihihi_1608478638207TestRequestConfig, ReturnType<typeof hihihi_1608478638207Test>>(hihihi_1608478638207Test)
 
 /**
  * 接口 [返回 raw↗](http://foo.bar/project/11/interface/api/129) 的 **请求类型**
@@ -61324,7 +61582,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61350,7 +61608,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61369,7 +61627,7 @@ rawResponseTest.requestConfig = rawResponseTestRequestConfig
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const useRawResponseTest = makeRequestHook<RawResponseTestRequest, RawResponseTestRequestConfig, ReturnType<typeof rawResponseTest>>(rawResponseTest)
+export const useRawResponseTest = /*#__PURE__*/ makeRequestHook<RawResponseTestRequest, RawResponseTestRequestConfig, ReturnType<typeof rawResponseTest>>(rawResponseTest)
 
 /**
  * 接口 [请求头↗](http://foo.bar/project/11/interface/api/1087) 的 **请求类型**
@@ -61414,7 +61672,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61440,7 +61698,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61459,7 +61717,7 @@ headersTest.requestConfig = headersTestRequestConfig
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const useHeadersTest = makeRequestHook<HeadersTestRequest, HeadersTestRequestConfig, ReturnType<typeof headersTest>>(headersTest)
+export const useHeadersTest = /*#__PURE__*/ makeRequestHook<HeadersTestRequest, HeadersTestRequestConfig, ReturnType<typeof headersTest>>(headersTest)
 
 /**
  * 接口 [路径参数、查询参数类型↗](http://foo.bar/project/11/interface/api/1137) 的 **请求类型**
@@ -61517,7 +61775,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61543,7 +61801,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61562,7 +61820,7 @@ avatarTest.requestConfig = avatarTestRequestConfig
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const useAvatarTest = makeRequestHook<AvatarTestRequest, AvatarTestRequestConfig, ReturnType<typeof avatarTest>>(avatarTest)
+export const useAvatarTest = /*#__PURE__*/ makeRequestHook<AvatarTestRequest, AvatarTestRequestConfig, ReturnType<typeof avatarTest>>(avatarTest)
 
 /**
  * 接口 [dataKey 深度路径↗](http://foo.bar/project/11/interface/api/1167) 的 **请求类型**
@@ -61617,7 +61875,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61643,7 +61901,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61662,7 +61920,7 @@ deepTest.requestConfig = deepTestRequestConfig
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const useDeepTest = makeRequestHook<DeepTestRequest, DeepTestRequestConfig, ReturnType<typeof deepTest>>(deepTest)
+export const useDeepTest = /*#__PURE__*/ makeRequestHook<DeepTestRequest, DeepTestRequestConfig, ReturnType<typeof deepTest>>(deepTest)
 
 /**
  * 接口 [fix: 仅 POST 类接口处理表单数据↗](http://foo.bar/project/11/interface/api/1345) 的 **请求类型**
@@ -61712,7 +61970,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61738,7 +61996,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -61757,7 +62015,7 @@ onlyPostFormDataTest.requestConfig = onlyPostFormDataTestRequestConfig
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const useOnlyPostFormDataTest = makeRequestHook<OnlyPostFormDataTestRequest, OnlyPostFormDataTestRequestConfig, ReturnType<typeof onlyPostFormDataTest>>(onlyPostFormDataTest)",
+export const useOnlyPostFormDataTest = /*#__PURE__*/ makeRequestHook<OnlyPostFormDataTestRequest, OnlyPostFormDataTestRequestConfig, ReturnType<typeof onlyPostFormDataTest>>(onlyPostFormDataTest)",
 ]
 `;
 
@@ -61842,7 +62100,7 @@ type DeleteMethodTestRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61873,7 +62131,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const deleteMethodTest = /*#__PURE__*/ (requestData: DeleteMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeleteMethodTestResponse>(prepare(deleteMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -61938,7 +62196,7 @@ type GetMethodTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -61974,7 +62232,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const getMethodTest = /*#__PURE__*/ (requestData: GetMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<GetMethodTestResponse>(prepare(getMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -62029,7 +62287,7 @@ type Json5ResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62066,7 +62324,10 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (requestData?: Json5ResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const json5ResponseTest = /*#__PURE__*/ (
+  requestData?: Json5ResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<Json5ResponseTestResponse>(prepare(json5ResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -62142,7 +62403,7 @@ type Json5RequestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62184,7 +62445,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
+export const json5RequestTest = /*#__PURE__*/ (requestData: Json5RequestTestRequest, ...args: UserRequestRestArgs) => {
   return request<Json5RequestTestResponse>(prepare(json5RequestTestRequestConfig, requestData), ...args)
 }
 
@@ -62258,7 +62519,7 @@ type PostMethodTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62310,7 +62571,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const postMethodTest = /*#__PURE__*/ (requestData: PostMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PostMethodTestResponse>(prepare(postMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -62381,7 +62642,7 @@ type PutMethodTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62425,7 +62686,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
+export const putMethodTest = /*#__PURE__*/ (requestData: PutMethodTestRequest, ...args: UserRequestRestArgs) => {
   return request<PutMethodTestResponse>(prepare(putMethodTestRequestConfig, requestData), ...args)
 }
 
@@ -62501,7 +62762,7 @@ type DataKeyExampleTestRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62551,7 +62812,10 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (requestData: DataKeyExampleTestRequest, ...args: UserRequestRestArgs) => {
+export const dataKeyExampleTest = /*#__PURE__*/ (
+  requestData: DataKeyExampleTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<DataKeyExampleTestResponse>(prepare(dataKeyExampleTestRequestConfig, requestData), ...args)
 }
 
@@ -62611,7 +62875,7 @@ type UploadTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62645,7 +62909,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
+export const uploadTest = /*#__PURE__*/ (requestData: UploadTestRequest, ...args: UserRequestRestArgs) => {
   return request<UploadTestResponse>(prepare(uploadTestRequestConfig, requestData), ...args)
 }
 
@@ -62709,7 +62973,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62744,7 +63008,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -62795,7 +63059,7 @@ type NoResponseDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62821,7 +63085,10 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (requestData?: NoResponseDataTestRequest, ...args: UserRequestRestArgs) => {
+export const noResponseDataTest = /*#__PURE__*/ (
+  requestData?: NoResponseDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<NoResponseDataTestResponse>(prepare(noResponseDataTestRequestConfig, requestData), ...args)
 }
 
@@ -62872,7 +63139,7 @@ type EmptyResponseTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62898,7 +63165,10 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (requestData?: EmptyResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const emptyResponseTest = /*#__PURE__*/ (
+  requestData?: EmptyResponseTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<EmptyResponseTestResponse>(prepare(emptyResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -62958,7 +63228,7 @@ type TestTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -62995,7 +63265,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
+export const testTest = /*#__PURE__*/ (requestData: TestTestRequest, ...args: UserRequestRestArgs) => {
   return request<TestTestResponse>(prepare(testTestRequestConfig, requestData), ...args)
 }
 
@@ -63063,7 +63333,7 @@ type HihihiTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63099,7 +63369,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
+export const hihihiTest = /*#__PURE__*/ (requestData: HihihiTestRequest, ...args: UserRequestRestArgs) => {
   return request<HihihiTestResponse>(prepare(hihihiTestRequestConfig, requestData), ...args)
 }
 
@@ -63172,7 +63442,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63210,7 +63480,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -63264,7 +63534,7 @@ type RawResponseTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63290,7 +63560,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
+export const rawResponseTest = /*#__PURE__*/ (requestData?: RawResponseTestRequest, ...args: UserRequestRestArgs) => {
   return request<RawResponseTestResponse>(prepare(rawResponseTestRequestConfig, requestData), ...args)
 }
 
@@ -63341,7 +63611,7 @@ type HeadersTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63367,7 +63637,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
+export const headersTest = /*#__PURE__*/ (requestData?: HeadersTestRequest, ...args: UserRequestRestArgs) => {
   return request<HeadersTestResponse>(prepare(headersTestRequestConfig, requestData), ...args)
 }
 
@@ -63431,7 +63701,7 @@ type AvatarTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63466,7 +63736,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
+export const avatarTest = /*#__PURE__*/ (requestData: AvatarTestRequest, ...args: UserRequestRestArgs) => {
   return request<AvatarTestResponse>(prepare(avatarTestRequestConfig, requestData), ...args)
 }
 
@@ -63527,7 +63797,7 @@ type DeepTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63574,7 +63844,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
+export const deepTest = /*#__PURE__*/ (requestData?: DeepTestRequest, ...args: UserRequestRestArgs) => {
   return request<DeepTestResponse>(prepare(deepTestRequestConfig, requestData), ...args)
 }
 
@@ -63630,7 +63900,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63661,7 +63931,10 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (requestData: OnlyPostFormDataTestRequest, ...args: UserRequestRestArgs) => {
+export const onlyPostFormDataTest = /*#__PURE__*/ (
+  requestData: OnlyPostFormDataTestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<OnlyPostFormDataTestResponse>(prepare(onlyPostFormDataTestRequestConfig, requestData), ...args)
 }
 
@@ -63726,7 +63999,7 @@ type DeleteMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
+const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63752,7 +64025,7 @@ const deleteMethodTestRequestConfig: DeleteMethodTestRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod_test\`
  * @更新时间 1610557429
  */
-export const deleteMethodTest = (
+export const deleteMethodTest = /*#__PURE__*/ (
   requestData: DeleteMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -63821,7 +64094,7 @@ type GetMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
+const getMethodTestRequestConfig: GetMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63847,7 +64120,7 @@ const getMethodTestRequestConfig: GetMethodTestRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod_test\`
  * @更新时间 1610557429
  */
-export const getMethodTest = (
+export const getMethodTest = /*#__PURE__*/ (
   requestData: GetMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -63906,7 +64179,7 @@ type Json5ResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
+const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -63932,7 +64205,7 @@ const json5ResponseTestRequestConfig: Json5ResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response_test\`
  * @更新时间 1610557429
  */
-export const json5ResponseTest = (
+export const json5ResponseTest = /*#__PURE__*/ (
   requestData?: Json5ResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64012,7 +64285,7 @@ type Json5RequestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
+const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64038,7 +64311,7 @@ const json5RequestTestRequestConfig: Json5RequestTestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request_test\`
  * @更新时间 1610557429
  */
-export const json5RequestTest = (
+export const json5RequestTest = /*#__PURE__*/ (
   requestData: Json5RequestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64116,7 +64389,7 @@ type PostMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
+const postMethodTestRequestConfig: PostMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64142,7 +64415,7 @@ const postMethodTestRequestConfig: PostMethodTestRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod_test\`
  * @更新时间 1610557429
  */
-export const postMethodTest = (
+export const postMethodTest = /*#__PURE__*/ (
   requestData: PostMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64217,7 +64490,7 @@ type PutMethodTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
+const putMethodTestRequestConfig: PutMethodTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64243,7 +64516,7 @@ const putMethodTestRequestConfig: PutMethodTestRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod_test\`
  * @更新时间 1610557429
  */
-export const putMethodTest = (
+export const putMethodTest = /*#__PURE__*/ (
   requestData: PutMethodTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64323,7 +64596,7 @@ type DataKeyExampleTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
+const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64349,7 +64622,7 @@ const dataKeyExampleTestRequestConfig: DataKeyExampleTestRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample_test\`
  * @更新时间 1610557430
  */
-export const dataKeyExampleTest = (
+export const dataKeyExampleTest = /*#__PURE__*/ (
   requestData: DataKeyExampleTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64413,7 +64686,7 @@ type UploadTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-const uploadTestRequestConfig: UploadTestRequestConfig = {
+const uploadTestRequestConfig: UploadTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64439,7 +64712,7 @@ const uploadTestRequestConfig: UploadTestRequestConfig = {
  * @请求头 \`POST /__hello__/upload_test\`
  * @更新时间 1610557430
  */
-export const uploadTest = (
+export const uploadTest = /*#__PURE__*/ (
   requestData: UploadTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64507,7 +64780,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64533,7 +64806,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64588,7 +64861,7 @@ type NoResponseDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
+const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64614,7 +64887,7 @@ const noResponseDataTestRequestConfig: NoResponseDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData_test\`
  * @更新时间 1610557430
  */
-export const noResponseDataTest = (
+export const noResponseDataTest = /*#__PURE__*/ (
   requestData?: NoResponseDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64669,7 +64942,7 @@ type EmptyResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
+const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64695,7 +64968,7 @@ const emptyResponseTestRequestConfig: EmptyResponseTestRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse_test\`
  * @更新时间 1610557430
  */
-export const emptyResponseTest = (
+export const emptyResponseTest = /*#__PURE__*/ (
   requestData?: EmptyResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64759,7 +65032,7 @@ type TestTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-const testTestRequestConfig: TestTestRequestConfig = {
+const testTestRequestConfig: TestTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64785,7 +65058,7 @@ const testTestRequestConfig: TestTestRequestConfig = {
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test_test\`
  * @更新时间 1610557430
  */
-export const testTest = (
+export const testTest = /*#__PURE__*/ (
   requestData: TestTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64857,7 +65130,7 @@ type HihihiTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-const hihihiTestRequestConfig: HihihiTestRequestConfig = {
+const hihihiTestRequestConfig: HihihiTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64883,7 +65156,7 @@ const hihihiTestRequestConfig: HihihiTestRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_test\`
  * @更新时间 1610557430
  */
-export const hihihiTest = (
+export const hihihiTest = /*#__PURE__*/ (
   requestData: HihihiTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -64960,7 +65233,7 @@ type Hihihi_1608478638207TestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = {
+const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -64986,7 +65259,7 @@ const hihihi_1608478638207TestRequestConfig: Hihihi_1608478638207TestRequestConf
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207_test\`
  * @更新时间 1610557430
  */
-export const hihihi_1608478638207Test = (
+export const hihihi_1608478638207Test = /*#__PURE__*/ (
   requestData: Hihihi_1608478638207TestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -65041,7 +65314,7 @@ type RawResponseTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
+const rawResponseTestRequestConfig: RawResponseTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -65067,7 +65340,7 @@ const rawResponseTestRequestConfig: RawResponseTestRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse_test\`
  * @更新时间 1610557430
  */
-export const rawResponseTest = (
+export const rawResponseTest = /*#__PURE__*/ (
   requestData?: RawResponseTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -65122,7 +65395,7 @@ type HeadersTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-const headersTestRequestConfig: HeadersTestRequestConfig = {
+const headersTestRequestConfig: HeadersTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -65148,7 +65421,7 @@ const headersTestRequestConfig: HeadersTestRequestConfig = {
  * @请求头 \`GET /__hello__/headers_test\`
  * @更新时间 1619432971
  */
-export const headersTest = (
+export const headersTest = /*#__PURE__*/ (
   requestData?: HeadersTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -65216,7 +65489,7 @@ type AvatarTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-const avatarTestRequestConfig: AvatarTestRequestConfig = {
+const avatarTestRequestConfig: AvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -65242,7 +65515,7 @@ const avatarTestRequestConfig: AvatarTestRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar_test\`
  * @更新时间 1621501310
  */
-export const avatarTest = (
+export const avatarTest = /*#__PURE__*/ (
   requestData: AvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -65307,7 +65580,7 @@ type DeepTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-const deepTestRequestConfig: DeepTestRequestConfig = {
+const deepTestRequestConfig: DeepTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -65333,7 +65606,7 @@ const deepTestRequestConfig: DeepTestRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep_test\`
  * @更新时间 1626489548
  */
-export const deepTest = (
+export const deepTest = /*#__PURE__*/ (
   requestData?: DeepTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -65393,7 +65666,7 @@ type OnlyPostFormDataTestRequestConfig = Readonly<RequestConfig<
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
+const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_0,
   devUrl: devUrl_0_0_0_0,
   prodUrl: prodUrl_0_0_0_0,
@@ -65419,7 +65692,7 @@ const onlyPostFormDataTestRequestConfig: OnlyPostFormDataTestRequestConfig = {
  * @请求头 \`GET /__hello__/get/only_post_form_data_test\`
  * @更新时间 1632493928
  */
-export const onlyPostFormDataTest = (
+export const onlyPostFormDataTest = /*#__PURE__*/ (
   requestData: OnlyPostFormDataTestRequest,
   ...args: UserRequestRestArgs
 ) => {

--- a/tests/__snapshots__/cli.test.ts.snap
+++ b/tests/__snapshots__/cli.test.ts.snap
@@ -216,7 +216,7 @@ type HelloDeleteMethodRequestConfig = Readonly<
  * @请求头 \`DELETE /__hello__/deleteMethod\`
  * @更新时间 1610557429
  */
-const helloDeleteMethodRequestConfig: HelloDeleteMethodRequestConfig = {
+const helloDeleteMethodRequestConfig: HelloDeleteMethodRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -242,7 +242,10 @@ const helloDeleteMethodRequestConfig: HelloDeleteMethodRequestConfig = {
  * @请求头 \`DELETE /__hello__/deleteMethod\`
  * @更新时间 1610557429
  */
-export const helloDeleteMethod = (requestData: HelloDeleteMethodRequest, ...args: UserRequestRestArgs) => {
+export const helloDeleteMethod = /*#__PURE__*/ (
+  requestData: HelloDeleteMethodRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloDeleteMethodResponse>(prepare(helloDeleteMethodRequestConfig, requestData), ...args)
 }
 
@@ -307,7 +310,7 @@ type HelloGetMethodRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/getMethod\`
  * @更新时间 1610557429
  */
-const helloGetMethodRequestConfig: HelloGetMethodRequestConfig = {
+const helloGetMethodRequestConfig: HelloGetMethodRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -333,7 +336,7 @@ const helloGetMethodRequestConfig: HelloGetMethodRequestConfig = {
  * @请求头 \`GET /__hello__/getMethod\`
  * @更新时间 1610557429
  */
-export const helloGetMethod = (requestData: HelloGetMethodRequest, ...args: UserRequestRestArgs) => {
+export const helloGetMethod = /*#__PURE__*/ (requestData: HelloGetMethodRequest, ...args: UserRequestRestArgs) => {
   return request<HelloGetMethodResponse>(prepare(helloGetMethodRequestConfig, requestData), ...args)
 }
 
@@ -388,7 +391,7 @@ type HelloJson5ResponseRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/json5Response\`
  * @更新时间 1610557429
  */
-const helloJson5ResponseRequestConfig: HelloJson5ResponseRequestConfig = {
+const helloJson5ResponseRequestConfig: HelloJson5ResponseRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -414,7 +417,10 @@ const helloJson5ResponseRequestConfig: HelloJson5ResponseRequestConfig = {
  * @请求头 \`GET /__hello__/json5Response\`
  * @更新时间 1610557429
  */
-export const helloJson5Response = (requestData?: HelloJson5ResponseRequest, ...args: UserRequestRestArgs) => {
+export const helloJson5Response = /*#__PURE__*/ (
+  requestData?: HelloJson5ResponseRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloJson5ResponseResponse>(prepare(helloJson5ResponseRequestConfig, requestData), ...args)
 }
 
@@ -490,7 +496,7 @@ type HelloJson5RequestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/json5Request\`
  * @更新时间 1610557429
  */
-const helloJson5RequestRequestConfig: HelloJson5RequestRequestConfig = {
+const helloJson5RequestRequestConfig: HelloJson5RequestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -516,7 +522,10 @@ const helloJson5RequestRequestConfig: HelloJson5RequestRequestConfig = {
  * @请求头 \`POST /__hello__/json5Request\`
  * @更新时间 1610557429
  */
-export const helloJson5Request = (requestData: HelloJson5RequestRequest, ...args: UserRequestRestArgs) => {
+export const helloJson5Request = /*#__PURE__*/ (
+  requestData: HelloJson5RequestRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloJson5RequestResponse>(prepare(helloJson5RequestRequestConfig, requestData), ...args)
 }
 
@@ -590,7 +599,7 @@ type HelloPostMethodRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/postMethod\`
  * @更新时间 1610557429
  */
-const helloPostMethodRequestConfig: HelloPostMethodRequestConfig = {
+const helloPostMethodRequestConfig: HelloPostMethodRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -616,7 +625,7 @@ const helloPostMethodRequestConfig: HelloPostMethodRequestConfig = {
  * @请求头 \`POST /__hello__/postMethod\`
  * @更新时间 1610557429
  */
-export const helloPostMethod = (requestData: HelloPostMethodRequest, ...args: UserRequestRestArgs) => {
+export const helloPostMethod = /*#__PURE__*/ (requestData: HelloPostMethodRequest, ...args: UserRequestRestArgs) => {
   return request<HelloPostMethodResponse>(prepare(helloPostMethodRequestConfig, requestData), ...args)
 }
 
@@ -687,7 +696,7 @@ type HelloPutMethodRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/putMethod\`
  * @更新时间 1610557429
  */
-const helloPutMethodRequestConfig: HelloPutMethodRequestConfig = {
+const helloPutMethodRequestConfig: HelloPutMethodRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -713,7 +722,7 @@ const helloPutMethodRequestConfig: HelloPutMethodRequestConfig = {
  * @请求头 \`PUT /__hello__/putMethod\`
  * @更新时间 1610557429
  */
-export const helloPutMethod = (requestData: HelloPutMethodRequest, ...args: UserRequestRestArgs) => {
+export const helloPutMethod = /*#__PURE__*/ (requestData: HelloPutMethodRequest, ...args: UserRequestRestArgs) => {
   return request<HelloPutMethodResponse>(prepare(helloPutMethodRequestConfig, requestData), ...args)
 }
 
@@ -789,7 +798,7 @@ type HelloDataKeyExampleRequestConfig = Readonly<
  * @请求头 \`PUT /__hello__/dataKeyExample\`
  * @更新时间 1610557430
  */
-const helloDataKeyExampleRequestConfig: HelloDataKeyExampleRequestConfig = {
+const helloDataKeyExampleRequestConfig: HelloDataKeyExampleRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -815,7 +824,10 @@ const helloDataKeyExampleRequestConfig: HelloDataKeyExampleRequestConfig = {
  * @请求头 \`PUT /__hello__/dataKeyExample\`
  * @更新时间 1610557430
  */
-export const helloDataKeyExample = (requestData: HelloDataKeyExampleRequest, ...args: UserRequestRestArgs) => {
+export const helloDataKeyExample = /*#__PURE__*/ (
+  requestData: HelloDataKeyExampleRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloDataKeyExampleResponse>(prepare(helloDataKeyExampleRequestConfig, requestData), ...args)
 }
 
@@ -866,7 +878,7 @@ type HelloUploadRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/upload\`
  * @更新时间 1610557430
  */
-const helloUploadRequestConfig: HelloUploadRequestConfig = {
+const helloUploadRequestConfig: HelloUploadRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -892,7 +904,7 @@ const helloUploadRequestConfig: HelloUploadRequestConfig = {
  * @请求头 \`POST /__hello__/upload\`
  * @更新时间 1610557430
  */
-export const helloUpload = (requestData: HelloUploadRequest, ...args: UserRequestRestArgs) => {
+export const helloUpload = /*#__PURE__*/ (requestData: HelloUploadRequest, ...args: UserRequestRestArgs) => {
   return request<HelloUploadResponse>(prepare(helloUploadRequestConfig, requestData), ...args)
 }
 
@@ -947,7 +959,7 @@ type HelloTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test\`
  * @更新时间 1610557430
  */
-const helloTestRequestConfig: HelloTestRequestConfig = {
+const helloTestRequestConfig: HelloTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -973,7 +985,7 @@ const helloTestRequestConfig: HelloTestRequestConfig = {
  * @请求头 \`POST /__hello__/test\`
  * @更新时间 1610557430
  */
-export const helloTest = (requestData: HelloTestRequest, ...args: UserRequestRestArgs) => {
+export const helloTest = /*#__PURE__*/ (requestData: HelloTestRequest, ...args: UserRequestRestArgs) => {
   return request<HelloTestResponse>(prepare(helloTestRequestConfig, requestData), ...args)
 }
 
@@ -1024,7 +1036,7 @@ type HelloNoResponseDataRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/noResponseData\`
  * @更新时间 1610557430
  */
-const helloNoResponseDataRequestConfig: HelloNoResponseDataRequestConfig = {
+const helloNoResponseDataRequestConfig: HelloNoResponseDataRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1050,7 +1062,10 @@ const helloNoResponseDataRequestConfig: HelloNoResponseDataRequestConfig = {
  * @请求头 \`GET /__hello__/noResponseData\`
  * @更新时间 1610557430
  */
-export const helloNoResponseData = (requestData?: HelloNoResponseDataRequest, ...args: UserRequestRestArgs) => {
+export const helloNoResponseData = /*#__PURE__*/ (
+  requestData?: HelloNoResponseDataRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloNoResponseDataResponse>(prepare(helloNoResponseDataRequestConfig, requestData), ...args)
 }
 
@@ -1101,7 +1116,7 @@ type HelloEmptyResponseRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/emptyResponse\`
  * @更新时间 1610557430
  */
-const helloEmptyResponseRequestConfig: HelloEmptyResponseRequestConfig = {
+const helloEmptyResponseRequestConfig: HelloEmptyResponseRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1127,7 +1142,10 @@ const helloEmptyResponseRequestConfig: HelloEmptyResponseRequestConfig = {
  * @请求头 \`POST /__hello__/emptyResponse\`
  * @更新时间 1610557430
  */
-export const helloEmptyResponse = (requestData?: HelloEmptyResponseRequest, ...args: UserRequestRestArgs) => {
+export const helloEmptyResponse = /*#__PURE__*/ (
+  requestData?: HelloEmptyResponseRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloEmptyResponseResponse>(prepare(helloEmptyResponseRequestConfig, requestData), ...args)
 }
 
@@ -1187,7 +1205,7 @@ type HelloPathIdHelloNamePassAvatarTestRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test\`
  * @更新时间 1610557430
  */
-const helloPathIdHelloNamePassAvatarTestRequestConfig: HelloPathIdHelloNamePassAvatarTestRequestConfig = {
+const helloPathIdHelloNamePassAvatarTestRequestConfig: HelloPathIdHelloNamePassAvatarTestRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1213,7 +1231,7 @@ const helloPathIdHelloNamePassAvatarTestRequestConfig: HelloPathIdHelloNamePassA
  * @请求头 \`POST /__hello__/path/:id/hello/:name/:pass/{avatar}/:test\`
  * @更新时间 1610557430
  */
-export const helloPathIdHelloNamePassAvatarTest = (
+export const helloPathIdHelloNamePassAvatarTest = /*#__PURE__*/ (
   requestData: HelloPathIdHelloNamePassAvatarTestRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -1287,7 +1305,7 @@ type HelloTestIdHihihiRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi\`
  * @更新时间 1610557430
  */
-const helloTestIdHihihiRequestConfig: HelloTestIdHihihiRequestConfig = {
+const helloTestIdHihihiRequestConfig: HelloTestIdHihihiRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1313,7 +1331,10 @@ const helloTestIdHihihiRequestConfig: HelloTestIdHihihiRequestConfig = {
  * @请求头 \`POST /__hello__/test/{id}/:hihihi\`
  * @更新时间 1610557430
  */
-export const helloTestIdHihihi = (requestData: HelloTestIdHihihiRequest, ...args: UserRequestRestArgs) => {
+export const helloTestIdHihihi = /*#__PURE__*/ (
+  requestData: HelloTestIdHihihiRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloTestIdHihihiResponse>(prepare(helloTestIdHihihiRequestConfig, requestData), ...args)
 }
 
@@ -1386,7 +1407,7 @@ type HelloTestIdHihihi_1608478638207RequestConfig = Readonly<
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207\`
  * @更新时间 1610557430
  */
-const helloTestIdHihihi_1608478638207RequestConfig: HelloTestIdHihihi_1608478638207RequestConfig = {
+const helloTestIdHihihi_1608478638207RequestConfig: HelloTestIdHihihi_1608478638207RequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1412,7 +1433,7 @@ const helloTestIdHihihi_1608478638207RequestConfig: HelloTestIdHihihi_1608478638
  * @请求头 \`POST /__hello__/test/{id}/:hihihi_1608478638207\`
  * @更新时间 1610557430
  */
-export const helloTestIdHihihi_1608478638207 = (
+export const helloTestIdHihihi_1608478638207 = /*#__PURE__*/ (
   requestData: HelloTestIdHihihi_1608478638207Request,
   ...args: UserRequestRestArgs
 ) => {
@@ -1469,7 +1490,7 @@ type HelloRawResponseRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/rawResponse\`
  * @更新时间 1610557430
  */
-const helloRawResponseRequestConfig: HelloRawResponseRequestConfig = {
+const helloRawResponseRequestConfig: HelloRawResponseRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1495,7 +1516,7 @@ const helloRawResponseRequestConfig: HelloRawResponseRequestConfig = {
  * @请求头 \`GET /__hello__/rawResponse\`
  * @更新时间 1610557430
  */
-export const helloRawResponse = (requestData?: HelloRawResponseRequest, ...args: UserRequestRestArgs) => {
+export const helloRawResponse = /*#__PURE__*/ (requestData?: HelloRawResponseRequest, ...args: UserRequestRestArgs) => {
   return request<HelloRawResponseResponse>(prepare(helloRawResponseRequestConfig, requestData), ...args)
 }
 
@@ -1537,7 +1558,7 @@ type HelloHeadersRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/headers\`
  * @更新时间 1619432971
  */
-const helloHeadersRequestConfig: HelloHeadersRequestConfig = {
+const helloHeadersRequestConfig: HelloHeadersRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1563,7 +1584,7 @@ const helloHeadersRequestConfig: HelloHeadersRequestConfig = {
  * @请求头 \`GET /__hello__/headers\`
  * @更新时间 1619432971
  */
-export const helloHeaders = (requestData?: HelloHeadersRequest, ...args: UserRequestRestArgs) => {
+export const helloHeaders = /*#__PURE__*/ (requestData?: HelloHeadersRequest, ...args: UserRequestRestArgs) => {
   return request<HelloHeadersResponse>(prepare(helloHeadersRequestConfig, requestData), ...args)
 }
 
@@ -1627,7 +1648,7 @@ type HelloUserIdAvatarRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/user/:id/avatar\`
  * @更新时间 1621501310
  */
-const helloUserIdAvatarRequestConfig: HelloUserIdAvatarRequestConfig = {
+const helloUserIdAvatarRequestConfig: HelloUserIdAvatarRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1653,7 +1674,10 @@ const helloUserIdAvatarRequestConfig: HelloUserIdAvatarRequestConfig = {
  * @请求头 \`GET /__hello__/user/:id/avatar\`
  * @更新时间 1621501310
  */
-export const helloUserIdAvatar = (requestData: HelloUserIdAvatarRequest, ...args: UserRequestRestArgs) => {
+export const helloUserIdAvatar = /*#__PURE__*/ (
+  requestData: HelloUserIdAvatarRequest,
+  ...args: UserRequestRestArgs
+) => {
   return request<HelloUserIdAvatarResponse>(prepare(helloUserIdAvatarRequestConfig, requestData), ...args)
 }
 
@@ -1714,7 +1738,7 @@ type HelloDataKeyDeepRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/dataKey/deep\`
  * @更新时间 1626489548
  */
-const helloDataKeyDeepRequestConfig: HelloDataKeyDeepRequestConfig = {
+const helloDataKeyDeepRequestConfig: HelloDataKeyDeepRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1740,7 +1764,7 @@ const helloDataKeyDeepRequestConfig: HelloDataKeyDeepRequestConfig = {
  * @请求头 \`GET /__hello__/dataKey/deep\`
  * @更新时间 1626489548
  */
-export const helloDataKeyDeep = (requestData?: HelloDataKeyDeepRequest, ...args: UserRequestRestArgs) => {
+export const helloDataKeyDeep = /*#__PURE__*/ (requestData?: HelloDataKeyDeepRequest, ...args: UserRequestRestArgs) => {
   return request<HelloDataKeyDeepResponse>(prepare(helloDataKeyDeepRequestConfig, requestData), ...args)
 }
 
@@ -1796,7 +1820,7 @@ type HelloGetOnlyPostFormDataRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get/only_post_form_data\`
  * @更新时间 1632493928
  */
-const helloGetOnlyPostFormDataRequestConfig: HelloGetOnlyPostFormDataRequestConfig = {
+const helloGetOnlyPostFormDataRequestConfig: HelloGetOnlyPostFormDataRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_1,
   devUrl: devUrl_0_0_0_1,
   prodUrl: prodUrl_0_0_0_1,
@@ -1822,7 +1846,7 @@ const helloGetOnlyPostFormDataRequestConfig: HelloGetOnlyPostFormDataRequestConf
  * @请求头 \`GET /__hello__/get/only_post_form_data\`
  * @更新时间 1632493928
  */
-export const helloGetOnlyPostFormData = (
+export const helloGetOnlyPostFormData = /*#__PURE__*/ (
   requestData: HelloGetOnlyPostFormDataRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -1878,7 +1902,7 @@ type HelloGet2RequestConfig = Readonly<
  * @请求头 \`GET /__hello__/get2\`
  * @更新时间 1610557430
  */
-const helloGet2RequestConfig: HelloGet2RequestConfig = {
+const helloGet2RequestConfig: HelloGet2RequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_2,
   devUrl: devUrl_0_0_0_2,
   prodUrl: prodUrl_0_0_0_2,
@@ -1905,7 +1929,7 @@ const helloGet2RequestConfig: HelloGet2RequestConfig = {
  * @请求头 \`GET /__hello__/get2\`
  * @更新时间 1610557430
  */
-export const helloGet2 = (requestData?: HelloGet2Request, ...args: UserRequestRestArgs) => {
+export const helloGet2 = /*#__PURE__*/ (requestData?: HelloGet2Request, ...args: UserRequestRestArgs) => {
   return request<HelloGet2Response>(prepare(helloGet2RequestConfig, requestData), ...args)
 }
 
@@ -1961,7 +1985,7 @@ type HelloIssue_17Picture_3dDetailRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail\`
  * @更新时间 1610557430
  */
-const helloIssue_17Picture_3dDetailRequestConfig: HelloIssue_17Picture_3dDetailRequestConfig = {
+const helloIssue_17Picture_3dDetailRequestConfig: HelloIssue_17Picture_3dDetailRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -1987,7 +2011,7 @@ const helloIssue_17Picture_3dDetailRequestConfig: HelloIssue_17Picture_3dDetailR
  * @请求头 \`GET /__hello__/issue-17/picture_3d_detail\`
  * @更新时间 1610557430
  */
-export const helloIssue_17Picture_3dDetail = (
+export const helloIssue_17Picture_3dDetail = /*#__PURE__*/ (
   requestData?: HelloIssue_17Picture_3dDetailRequest,
   ...args: UserRequestRestArgs
 ) => {
@@ -2049,7 +2073,7 @@ type Hello_28GetRequestConfig = Readonly<
  * @请求头 \`GET /__hello__/28/get\`
  * @更新时间 1610557430
  */
-const hello_28GetRequestConfig: Hello_28GetRequestConfig = {
+const hello_28GetRequestConfig: Hello_28GetRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -2075,7 +2099,7 @@ const hello_28GetRequestConfig: Hello_28GetRequestConfig = {
  * @请求头 \`GET /__hello__/28/get\`
  * @更新时间 1610557430
  */
-export const hello_28Get = (requestData: Hello_28GetRequest, ...args: UserRequestRestArgs) => {
+export const hello_28Get = /*#__PURE__*/ (requestData: Hello_28GetRequest, ...args: UserRequestRestArgs) => {
   return request<Hello_28GetResponse>(prepare(hello_28GetRequestConfig, requestData), ...args)
 }
 
@@ -2132,7 +2156,7 @@ type Hello_28PostFormRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/28/post/form\`
  * @更新时间 1610557431
  */
-const hello_28PostFormRequestConfig: Hello_28PostFormRequestConfig = {
+const hello_28PostFormRequestConfig: Hello_28PostFormRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -2158,7 +2182,7 @@ const hello_28PostFormRequestConfig: Hello_28PostFormRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/form\`
  * @更新时间 1610557431
  */
-export const hello_28PostForm = (requestData: Hello_28PostFormRequest, ...args: UserRequestRestArgs) => {
+export const hello_28PostForm = /*#__PURE__*/ (requestData: Hello_28PostFormRequest, ...args: UserRequestRestArgs) => {
   return request<Hello_28PostFormResponse>(prepare(hello_28PostFormRequestConfig, requestData), ...args)
 }
 
@@ -2224,7 +2248,7 @@ type Hello_28PostJsonRequestConfig = Readonly<
  * @请求头 \`POST /__hello__/28/post/json\`
  * @更新时间 1610557431
  */
-const hello_28PostJsonRequestConfig: Hello_28PostJsonRequestConfig = {
+const hello_28PostJsonRequestConfig: Hello_28PostJsonRequestConfig = /*#__PURE__*/ {
   mockUrl: mockUrl_0_0_0_3,
   devUrl: devUrl_0_0_0_3,
   prodUrl: prodUrl_0_0_0_3,
@@ -2250,7 +2274,7 @@ const hello_28PostJsonRequestConfig: Hello_28PostJsonRequestConfig = {
  * @请求头 \`POST /__hello__/28/post/json\`
  * @更新时间 1610557431
  */
-export const hello_28PostJson = (requestData: Hello_28PostJsonRequest, ...args: UserRequestRestArgs) => {
+export const hello_28PostJson = /*#__PURE__*/ (requestData: Hello_28PostJsonRequest, ...args: UserRequestRestArgs) => {
   return request<Hello_28PostJsonResponse>(prepare(hello_28PostJsonRequestConfig, requestData), ...args)
 }
 


### PR DESCRIPTION
增加 /*#__PURE__*/ 使 webpack 的 tree shaking 生效。

相关的参考文章：
@see https://webpack.js.org/guides/tree-shaking/#mark-a-function-call-as-side-effect-free
@see https://terser.org/docs/api-reference.html#annotations