### PR TITLE
修正没有正确使用 esm 导致在 cloudflare worker 环境中无法正常运行问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/esm/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
+  },
   "bin": {
     "ytt": "lib/cjs/cli.js"
   },


### PR DESCRIPTION
我在 Nuxt3 中使用了此项目，并打包为 cloudflare_module 预设，但最终的代码无法运行，提示错误：

 TypeError: _interopRequireDefault is not a function
at .output/server/chunks/build/server.mjs

追踪代码发现打包时并没有正确使用esm版本，而是使用了 cjs 版本。尝试将 packages.json 中的 main 指向 esm 版本问题消失。

AI 的解释是：

> 问题在于，现代的 Node.js 版本（特别是当消费者的项目 package.json 中设置了 "type": "module" 时）在解析 import 语句时，会优先遵循一个新的、更强大的标准："exports" 字段。
> 当您的 package.json 中没有 "exports" 字段时，Node.js 的 ESM 解析器会回退（fallback）到使用 "main" 字段作为包的入口点，即使您正在使用 import 语法。这就导致了即使用户尝试使用 ESM，最终加载的还是您在 "main" 中指定的 CJS 版本。"module" 字段主要被打包工具识别，而没有被 Node.js 的原生 ESM 加载器正式作为标准。


尝试加入了 exports 后问题消失。 这里建议加入避免此类问题。